### PR TITLE
fix: modify inject options to reflect Scratch behaviors

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -664,8 +664,11 @@ Blocks.propTypes = {
 Blocks.defaultOptions = {
     zoom: {
         controls: true,
-        wheel: true,
+        wheel: false,
         startScale: BLOCKS_DEFAULT_SCALE
+    },
+    move: {
+      wheel: true,
     },
     grid: {
         spacing: 40,
@@ -674,7 +677,8 @@ Blocks.defaultOptions = {
     },
     comments: true,
     collapse: false,
-    sounds: false
+    sounds: false,
+    trashcan: false,
 };
 
 Blocks.defaultProps = {


### PR DESCRIPTION
This PR updates the injection options to align Blockly's behaviors with Scratch. Specifically, it hides the trashcan and uses scrolling for scrolling rather than zooming.