### PR TITLE
fix: patch the getCheckboxState method in the new flyout

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -328,7 +328,7 @@ export default function (vm, useCatBlocks) {
         this.jsonInit(json);
     };
 
-    ScratchBlocks.VerticalFlyout.getCheckboxState = function (blockId) {
+    ScratchBlocks.CheckableContinuousFlyout.prototype.getCheckboxState = function (blockId) {
         const monitoredBlock = vm.runtime.monitorBlocks._blocks[blockId];
         return monitoredBlock ? monitoredBlock.isMonitored : false;
     };


### PR DESCRIPTION
This PR patches the getCheckboxState method on the new class added in https://github.com/gonfunko/scratch-blocks/pull/43.