### PR TITLE
fix: select extension categories when added

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -500,7 +500,8 @@ class Blocks extends React.Component {
         }
 
         this.withToolboxUpdates(() => {
-            this.workspace.toolbox_.setSelectedCategoryById(categoryId);
+            const toolbox = this.workspace.getToolbox();
+            toolbox.setSelectedItem(toolbox.getToolboxItemById(categoryId));
         });
     }
     setBlocks (blocks) {


### PR DESCRIPTION
This PR selects extension toolbox categories when an extension is added, and makes `handleCategorySelected` work in general.