### PR TITLE
fix: Use toolboxitemid instead of id as the identifier attribute for toolbox categories

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -13,7 +13,7 @@ const motion = function (isInitialSetup, isStage, targetId, colors) {
     );
     // Note: the category's secondaryColour matches up with the blocks' tertiary color, both used for border color.
     return `
-    <category name="${ScratchBlocks.ScratchMsgs.translate('CATEGORY_MOTION', 'Motion')}" id="motion" colour="${colors.primary}" secondaryColour="${colors.tertiary}">
+    <category name="${ScratchBlocks.ScratchMsgs.translate('CATEGORY_MOTION', 'Motion')}" toolboxitemid="motion" colour="${colors.primary}" secondaryColour="${colors.tertiary}">
         ${isStage ? `
         <label text="${stageSelected}"></label>
         ` : `
@@ -158,7 +158,7 @@ const looks = function (isInitialSetup, isStage, targetId, costumeName, backdrop
     const hmm = ScratchBlocks.ScratchMsgs.translate('LOOKS_HMM', 'Hmm...');
     // Note: the category's secondaryColour matches up with the blocks' tertiary color, both used for border color.
     return `
-    <category name="${ScratchBlocks.ScratchMsgs.translate('CATEGORY_LOOKS', 'Looks')}" id="looks" colour="${colors.primary}" secondaryColour="${colors.tertiary}">
+    <category name="${ScratchBlocks.ScratchMsgs.translate('CATEGORY_LOOKS', 'Looks')}" toolboxitemid="looks" colour="${colors.primary}" secondaryColour="${colors.tertiary}">
         ${isStage ? '' : `
         <block type="looks_sayforsecs">
             <value name="MESSAGE">
@@ -294,7 +294,7 @@ const looks = function (isInitialSetup, isStage, targetId, costumeName, backdrop
 const sound = function (isInitialSetup, isStage, targetId, soundName, colors) {
     // Note: the category's secondaryColour matches up with the blocks' tertiary color, both used for border color.
     return `
-    <category name="${ScratchBlocks.ScratchMsgs.translate('CATEGORY_SOUND', 'Sound')}" id="sound" colour="${colors.primary}" secondaryColour="${colors.tertiary}">
+    <category name="${ScratchBlocks.ScratchMsgs.translate('CATEGORY_SOUND', 'Sound')}" toolboxitemid="sound" colour="${colors.primary}" secondaryColour="${colors.tertiary}">
         <block id="${targetId}_sound_playuntildone" type="sound_playuntildone">
             <value name="SOUND_MENU">
                 <shadow type="sound_sounds_menu">
@@ -350,7 +350,7 @@ const sound = function (isInitialSetup, isStage, targetId, soundName, colors) {
 const events = function (isInitialSetup, isStage, targetId, colors) {
     // Note: the category's secondaryColour matches up with the blocks' tertiary color, both used for border color.
     return `
-    <category name="${ScratchBlocks.ScratchMsgs.translate('CATEGORY_EVENTS', 'Events')}" id="events" colour="${colors.primary}" secondaryColour="${colors.tertiary}">
+    <category name="${ScratchBlocks.ScratchMsgs.translate('CATEGORY_EVENTS', 'Events')}" toolboxitemid="events" colour="${colors.primary}" secondaryColour="${colors.tertiary}">
         <block type="event_whenflagclicked"/>
         <block type="event_whenkeypressed">
         </block>
@@ -392,7 +392,7 @@ const control = function (isInitialSetup, isStage, targetId, colors) {
     return `
     <category
         name="${ScratchBlocks.ScratchMsgs.translate('CATEGORY_CONTROL', 'Control')}"
-        id="control"
+        toolboxitemid="control"
         colour="${colors.primary}"
         secondaryColour="${colors.tertiary}">
         <block type="control_wait">
@@ -445,7 +445,7 @@ const sensing = function (isInitialSetup, isStage, targetId, colors) {
     return `
     <category
         name="${ScratchBlocks.ScratchMsgs.translate('CATEGORY_SENSING', 'Sensing')}"
-        id="sensing"
+        toolboxitemid="sensing"
         colour="${colors.primary}"
         secondaryColour="${colors.tertiary}">
         ${isStage ? '' : `
@@ -527,7 +527,7 @@ const operators = function (isInitialSetup, isStage, targetId, colors) {
     return `
     <category
         name="${ScratchBlocks.ScratchMsgs.translate('CATEGORY_OPERATORS', 'Operators')}"
-        id="operators"
+        toolboxitemid="operators"
         colour="${colors.primary}"
         secondaryColour="${colors.tertiary}">
         <block type="operator_add">
@@ -716,7 +716,7 @@ const variables = function (isInitialSetup, isStage, targetId, colors) {
     return `
     <category
         name="${ScratchBlocks.ScratchMsgs.translate('CATEGORY_VARIABLES', 'Variables')}"
-        id="variables"
+        toolboxitemid="variables"
         colour="${colors.primary}"
         secondaryColour="${colors.tertiary}"
         custom="VARIABLE">
@@ -729,7 +729,7 @@ const myBlocks = function (isInitialSetup, isStage, targetId, colors) {
     return `
     <category
         name="${ScratchBlocks.ScratchMsgs.translate('CATEGORY_MYBLOCKS', 'My Blocks')}"
-        id="myBlocks"
+        toolboxitemid="myBlocks"
         colour="${colors.primary}"
         secondaryColour="${colors.tertiary}"
         custom="PROCEDURE">


### PR DESCRIPTION
This PR updates the toolbox definitions to use the "new" `toolboxitemid` attribute instead of the `id` attribute.