### PR TITLE
fix: call reportValue on the ScratchBlocks module instead of the workspace

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -358,7 +358,7 @@ class Blocks extends React.Component {
         // this.workspace.glowBlock(data.id, false);
     }
     onVisualReport (data) {
-        this.workspace.reportValue(data.id, data.value);
+        this.ScratchBlocks.reportValue(data.id, data.value);
     }
     getToolboxXML () {
         // Use try/catch because this requires digging pretty deep into the VM


### PR DESCRIPTION
https://github.com/gonfunko/scratch-blocks/pull/55 moves the reportValue method into its own utility function. This PR updates scratch-gui to call that.