### PR TITLE
fix: call the new glow methods on ScratchBlocks

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -352,10 +352,10 @@ class Blocks extends React.Component {
         this.ScratchBlocks.glowStack(data.id, false);
     }
     onBlockGlowOn (data) {
-        this.ScratchBlocks.glowBlock(data.id, true);
+        // No-op, support may be added in the future
     }
     onBlockGlowOff (data) {
-        this.ScratchBlocks.glowBlock(data.id, false);
+        // No-op, support may be added in the future
     }
     onVisualReport (data) {
         this.ScratchBlocks.reportValue(data.id, data.value);

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -346,16 +346,16 @@ class Blocks extends React.Component {
         }
     }
     onScriptGlowOn (data) {
-        // this.workspace.glowStack(data.id, true);
+        this.ScratchBlocks.glowStack(data.id, true);
     }
     onScriptGlowOff (data) {
-        // this.workspace.glowStack(data.id, false);
+        this.ScratchBlocks.glowStack(data.id, false);
     }
     onBlockGlowOn (data) {
-        // this.workspace.glowBlock(data.id, true);
+        this.ScratchBlocks.glowBlock(data.id, true);
     }
     onBlockGlowOff (data) {
-        // this.workspace.glowBlock(data.id, false);
+        this.ScratchBlocks.glowBlock(data.id, false);
     }
     onVisualReport (data) {
         this.ScratchBlocks.reportValue(data.id, data.value);


### PR DESCRIPTION
This PR calls the new glow-related methods added on ScratchBlocks in https://github.com/gonfunko/scratch-blocks/pull/57 rather than the old ones tacked on to the workspace.