### PR TITLE
fix: adjust key event filtering to fix the when key pressed block

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -85,7 +85,7 @@ const vmListenerHOC = function (WrappedComponent) {
         }
         handleKeyDown (e) {
             // Don't capture keys intended for Blockly inputs.
-            if (e.target !== document && e.target !== document.body) return;
+            if (e.target instanceof HTMLInputElement) return;
 
             const key = (!e.key || e.key === 'Dead') ? e.keyCode : e.key;
             this.props.vm.postIOData('keyboard', {


### PR DESCRIPTION
This PR modifies the key down event listener. Previously this was discarding any events targeting anything below the `<body>`, but this meant that the "when _ key pressed" block didn't trigger if the Blockly environment (as opposed to e.g. the stage or other bit of the UI) had focus. It's unclear to me why this behavior changed, but based on the existing comment I think adjusting the check to check for events targeted at an input element and discard only those is safe, and allows the "when _ key pressed" block to function as expected.

This fixes https://github.com/gonfunko/scratch-blocks/issues/72.