### PR TITLE
fix: allow typing into comments

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -85,7 +85,7 @@ const vmListenerHOC = function (WrappedComponent) {
         }
         handleKeyDown (e) {
             // Don't capture keys intended for Blockly inputs.
-            if (e.target instanceof HTMLInputElement) return;
+            if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
 
             const key = (!e.key || e.key === 'Dead') ? e.keyCode : e.key;
             this.props.vm.postIOData('keyboard', {


### PR DESCRIPTION
This PR allows users to type into comment fields (it kind of works without this, but you can't enter spaces).