### PR TITLE
feat: plumb Scratch variable support into the UI

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -1,39 +1,49 @@
-import bindAll from 'lodash.bindall';
-import debounce from 'lodash.debounce';
-import defaultsDeep from 'lodash.defaultsdeep';
-import makeToolboxXML from '../lib/make-toolbox-xml';
-import PropTypes from 'prop-types';
-import React from 'react';
-import VMScratchBlocks from '../lib/blocks';
-import VM from 'scratch-vm';
+import bindAll from "lodash.bindall";
+import debounce from "lodash.debounce";
+import defaultsDeep from "lodash.defaultsdeep";
+import makeToolboxXML from "../lib/make-toolbox-xml";
+import PropTypes from "prop-types";
+import React from "react";
+import VMScratchBlocks from "../lib/blocks";
+import VM from "scratch-vm";
 
-import log from '../lib/log.js';
-import Prompt from './prompt.jsx';
-import BlocksComponent from '../components/blocks/blocks.jsx';
-import ExtensionLibrary from './extension-library.jsx';
-import extensionData from '../lib/libraries/extensions/index.jsx';
-import CustomProcedures from './custom-procedures.jsx';
-import errorBoundaryHOC from '../lib/error-boundary-hoc.jsx';
-import {BLOCKS_DEFAULT_SCALE, STAGE_DISPLAY_SIZES} from '../lib/layout-constants';
-import DropAreaHOC from '../lib/drop-area-hoc.jsx';
-import DragConstants from '../lib/drag-constants';
-import defineDynamicBlock from '../lib/define-dynamic-block';
-import {DEFAULT_THEME, getColorsForTheme, themeMap} from '../lib/themes';
-import {injectExtensionBlockTheme, injectExtensionCategoryTheme} from '../lib/themes/blockHelpers';
-
-import {connect} from 'react-redux';
-import {updateToolbox} from '../reducers/toolbox';
-import {activateColorPicker} from '../reducers/color-picker';
-import {closeExtensionLibrary, openSoundRecorder, openConnectionModal} from '../reducers/modals';
-import {activateCustomProcedures, deactivateCustomProcedures} from '../reducers/custom-procedures';
-import {setConnectionModalExtensionId} from '../reducers/connection-modal';
-import {updateMetrics} from '../reducers/workspace-metrics';
-import {isTimeTravel2020} from '../reducers/time-travel';
-
+import log from "../lib/log.js";
+import Prompt from "./prompt.jsx";
+import BlocksComponent from "../components/blocks/blocks.jsx";
+import ExtensionLibrary from "./extension-library.jsx";
+import extensionData from "../lib/libraries/extensions/index.jsx";
+import CustomProcedures from "./custom-procedures.jsx";
+import errorBoundaryHOC from "../lib/error-boundary-hoc.jsx";
 import {
-    activateTab,
-    SOUNDS_TAB_INDEX
-} from '../reducers/editor-tab';
+    BLOCKS_DEFAULT_SCALE,
+    STAGE_DISPLAY_SIZES,
+} from "../lib/layout-constants";
+import DropAreaHOC from "../lib/drop-area-hoc.jsx";
+import DragConstants from "../lib/drag-constants";
+import defineDynamicBlock from "../lib/define-dynamic-block";
+import { DEFAULT_THEME, getColorsForTheme, themeMap } from "../lib/themes";
+import {
+    injectExtensionBlockTheme,
+    injectExtensionCategoryTheme,
+} from "../lib/themes/blockHelpers";
+
+import { connect } from "react-redux";
+import { updateToolbox } from "../reducers/toolbox";
+import { activateColorPicker } from "../reducers/color-picker";
+import {
+    closeExtensionLibrary,
+    openSoundRecorder,
+    openConnectionModal,
+} from "../reducers/modals";
+import {
+    activateCustomProcedures,
+    deactivateCustomProcedures,
+} from "../reducers/custom-procedures";
+import { setConnectionModalExtensionId } from "../reducers/connection-modal";
+import { updateMetrics } from "../reducers/workspace-metrics";
+import { isTimeTravel2020 } from "../reducers/time-travel";
+
+import { activateTab, SOUNDS_TAB_INDEX } from "../reducers/editor-tab";
 
 const addFunctionListener = (object, property, callback) => {
     const oldFn = object[property];
@@ -44,94 +54,122 @@ const addFunctionListener = (object, property, callback) => {
     };
 };
 
-const DroppableBlocks = DropAreaHOC([
-    DragConstants.BACKPACK_CODE
-])(BlocksComponent);
+const DroppableBlocks = DropAreaHOC([DragConstants.BACKPACK_CODE])(
+    BlocksComponent
+);
 
 class Blocks extends React.Component {
-    constructor (props) {
+    constructor(props) {
         super(props);
         this.ScratchBlocks = VMScratchBlocks(props.vm, false);
         bindAll(this, [
-            'attachVM',
-            'detachVM',
-            'getToolboxXML',
-            'handleCategorySelected',
-            'handleConnectionModalStart',
-            'handleDrop',
-            'handleStatusButtonUpdate',
-            'handleOpenSoundRecorder',
-            'handlePromptStart',
-            'handlePromptCallback',
-            'handlePromptClose',
-            'handleCustomProceduresClose',
-            'onScriptGlowOn',
-            'onScriptGlowOff',
-            'onBlockGlowOn',
-            'onBlockGlowOff',
-            'handleMonitorsUpdate',
-            'handleExtensionAdded',
-            'handleBlocksInfoUpdate',
-            'onTargetsUpdate',
-            'onVisualReport',
-            'onWorkspaceUpdate',
-            'onWorkspaceMetricsChange',
-            'setBlocks',
-            'setLocale'
+            "attachVM",
+            "detachVM",
+            "getToolboxXML",
+            "handleCategorySelected",
+            "handleConnectionModalStart",
+            "handleDrop",
+            "handleStatusButtonUpdate",
+            "handleOpenSoundRecorder",
+            "handlePromptStart",
+            "handlePromptCallback",
+            "handlePromptClose",
+            "handleCustomProceduresClose",
+            "onScriptGlowOn",
+            "onScriptGlowOff",
+            "onBlockGlowOn",
+            "onBlockGlowOff",
+            "handleMonitorsUpdate",
+            "handleExtensionAdded",
+            "handleBlocksInfoUpdate",
+            "onTargetsUpdate",
+            "onVisualReport",
+            "onWorkspaceUpdate",
+            "onWorkspaceMetricsChange",
+            "setBlocks",
+            "setLocale",
         ]);
         this.ScratchBlocks.dialog.setPrompt(this.handlePromptStart);
-        this.ScratchBlocks.statusButtonCallback = this.handleConnectionModalStart;
+        this.ScratchBlocks.statusButtonCallback =
+            this.handleConnectionModalStart;
         this.ScratchBlocks.recordSoundCallback = this.handleOpenSoundRecorder;
 
         this.state = {
-            prompt: null
+            prompt: null,
         };
         this.onTargetsUpdate = debounce(this.onTargetsUpdate, 100);
         this.toolboxUpdateQueue = [];
     }
-    componentDidMount () {
-        this.ScratchBlocks = VMScratchBlocks(this.props.vm, this.props.useCatBlocks);
+    componentDidMount() {
+        this.ScratchBlocks = VMScratchBlocks(
+            this.props.vm,
+            this.props.useCatBlocks
+        );
         this.ScratchBlocks.dialog.setPrompt(this.handlePromptStart);
-        this.ScratchBlocks.statusButtonCallback = this.handleConnectionModalStart;
+        this.ScratchBlocks.statusButtonCallback =
+            this.handleConnectionModalStart;
         this.ScratchBlocks.recordSoundCallback = this.handleOpenSoundRecorder;
 
-        this.ScratchBlocks.FieldColourSlider.activateEyedropper_ = this.props.onActivateColorPicker;
-        this.ScratchBlocks.ScratchProcedures.externalProcedureDefCallback = this.props.onActivateCustomProcedures;
+        this.ScratchBlocks.FieldColourSlider.activateEyedropper_ =
+            this.props.onActivateColorPicker;
+        this.ScratchBlocks.ScratchProcedures.externalProcedureDefCallback =
+            this.props.onActivateCustomProcedures;
         this.ScratchBlocks.ScratchMsgs.setLocale(this.props.locale);
 
-        const theme = this.ScratchBlocks.Theme.defineTheme('Scratch', {
-           'base': this.ScratchBlocks.Themes.Zelos,
-           'startHats': true
+        const theme = this.ScratchBlocks.Theme.defineTheme("Scratch", {
+            base: this.ScratchBlocks.Themes.Zelos,
+            startHats: true,
         });
-        const workspaceConfig = defaultsDeep({},
+        const workspaceConfig = defaultsDeep(
+            {},
             Blocks.defaultOptions,
             this.props.options,
             {
                 rtl: this.props.isRtl,
                 toolbox: this.props.toolboxXML,
                 colours: getColorsForTheme(this.props.theme),
-                renderer: 'zelos',
+                renderer: "zelos",
                 theme: theme,
             }
         );
-        this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
-        this.workspace.registerToolboxCategoryCallback('PROCEDURE',
-            this.ScratchBlocks.ScratchProcedures.getProceduresCategory);
+        this.workspace = this.ScratchBlocks.inject(
+            this.blocks,
+            workspaceConfig
+        );
+        this.workspace.registerToolboxCategoryCallback(
+            "PROCEDURE",
+            this.ScratchBlocks.ScratchProcedures.getProceduresCategory
+        );
 
         // Register buttons under new callback keys for creating variables,
         // lists, and procedures from extensions.
 
         const toolboxWorkspace = this.workspace.getFlyout().getWorkspace();
 
-        const varListButtonCallback = type =>
-            (() => this.ScratchBlocks.Variables.createVariable(this.workspace, null, type));
+        const varListButtonCallback = (type) => () =>
+            this.ScratchBlocks.Variables.createVariable(
+                this.workspace,
+                null,
+                type
+            );
         const procButtonCallback = () => {
-            this.ScratchBlocks.ScratchProcedures.createProcedureDefCallback(this.workspace);
+            this.ScratchBlocks.ScratchProcedures.createProcedureDefCallback(
+                this.workspace
+            );
         };
 
-        toolboxWorkspace.registerButtonCallback('MAKE_A_VARIABLE', varListButtonCallback(''));
-        toolboxWorkspace.registerButtonCallback('MAKE_A_LIST', varListButtonCallback('list'));
-        toolboxWorkspace.registerButtonCallback('MAKE_A_PROCEDURE', procButtonCallback);
+        toolboxWorkspace.registerButtonCallback(
+            "MAKE_A_VARIABLE",
+            varListButtonCallback("")
+        );
+        toolboxWorkspace.registerButtonCallback(
+            "MAKE_A_LIST",
+            varListButtonCallback("list")
+        );
+        toolboxWorkspace.registerButtonCallback(
+            "MAKE_A_PROCEDURE",
+            procButtonCallback
+        );
 
         // Store the xml of the toolbox that is actually rendered.
         // This is used in componentDidUpdate instead of prevProps, because
@@ -139,8 +177,16 @@ class Blocks extends React.Component {
         this._renderedToolboxXML = this.props.toolboxXML;
 
         // @todo change this when blockly supports UI events
-        addFunctionListener(this.workspace, 'translate', this.onWorkspaceMetricsChange);
-        addFunctionListener(this.workspace, 'zoom', this.onWorkspaceMetricsChange);
+        addFunctionListener(
+            this.workspace,
+            "translate",
+            this.onWorkspaceMetricsChange
+        );
+        addFunctionListener(
+            this.workspace,
+            "zoom",
+            this.onWorkspaceMetricsChange
+        );
         this.workspace.getToolbox().selectItemByPosition(0);
 
         this.attachVM();
@@ -150,19 +196,21 @@ class Blocks extends React.Component {
             this.setLocale();
         }
     }
-    shouldComponentUpdate (nextProps, nextState) {
+    shouldComponentUpdate(nextProps, nextState) {
         return (
             this.state.prompt !== nextState.prompt ||
             this.props.isVisible !== nextProps.isVisible ||
             this._renderedToolboxXML !== nextProps.toolboxXML ||
-            this.props.extensionLibraryVisible !== nextProps.extensionLibraryVisible ||
-            this.props.customProceduresVisible !== nextProps.customProceduresVisible ||
+            this.props.extensionLibraryVisible !==
+                nextProps.extensionLibraryVisible ||
+            this.props.customProceduresVisible !==
+                nextProps.customProceduresVisible ||
             this.props.locale !== nextProps.locale ||
             this.props.anyModalVisible !== nextProps.anyModalVisible ||
             this.props.stageSize !== nextProps.stageSize
         );
     }
-    componentDidUpdate (prevProps) {
+    componentDidUpdate(prevProps) {
         // If any modals are open, call hideChaff to close z-indexed field editors
         if (this.props.anyModalVisible && !prevProps.anyModalVisible) {
             this.ScratchBlocks.hideChaff();
@@ -171,22 +219,29 @@ class Blocks extends React.Component {
         // Only rerender the toolbox when the blocks are visible and the xml is
         // different from the previously rendered toolbox xml.
         // Do not check against prevProps.toolboxXML because that may not have been rendered.
-        if (this.props.isVisible && this.props.toolboxXML !== this._renderedToolboxXML) {
+        if (
+            this.props.isVisible &&
+            this.props.toolboxXML !== this._renderedToolboxXML
+        ) {
             this.requestToolboxUpdate();
         }
 
         if (this.props.isVisible === prevProps.isVisible) {
             if (this.props.stageSize !== prevProps.stageSize) {
                 // force workspace to redraw for the new stage size
-                window.dispatchEvent(new Event('resize'));
+                window.dispatchEvent(new Event("resize"));
             }
             return;
         }
         // @todo hack to resize blockly manually in case resize happened while hidden
         // @todo hack to reload the workspace due to gui bug #413
-        if (this.props.isVisible) { // Scripts tab
+        if (this.props.isVisible) {
+            // Scripts tab
             this.workspace.setVisible(true);
-            if (prevProps.locale !== this.props.locale || this.props.locale !== this.props.vm.getLocale()) {
+            if (
+                prevProps.locale !== this.props.locale ||
+                this.props.locale !== this.props.vm.getLocale()
+            ) {
                 // call setLocale if the locale has changed, or changed while the blocks were hidden.
                 // vm.getLocale() will be out of sync if locale was changed while not visible
                 this.setLocale();
@@ -195,12 +250,12 @@ class Blocks extends React.Component {
                 this.requestToolboxUpdate();
             }
 
-            window.dispatchEvent(new Event('resize'));
+            window.dispatchEvent(new Event("resize"));
         } else {
             this.workspace.setVisible(false);
         }
     }
-    componentWillUnmount () {
+    componentWillUnmount() {
         this.detachVM();
         this.workspace.dispose();
         clearTimeout(this.toolboxUpdateTimeout);
@@ -208,15 +263,16 @@ class Blocks extends React.Component {
         // Clear the flyout blocks so that they can be recreated on mount.
         this.props.vm.clearFlyoutBlocks();
     }
-    requestToolboxUpdate () {
+    requestToolboxUpdate() {
         clearTimeout(this.toolboxUpdateTimeout);
         this.toolboxUpdateTimeout = setTimeout(() => {
             this.updateToolbox();
         }, 0);
     }
-    setLocale () {
+    setLocale() {
         this.ScratchBlocks.ScratchMsgs.setLocale(this.props.locale);
-        this.props.vm.setLocale(this.props.locale, this.props.messages)
+        this.props.vm
+            .setLocale(this.props.locale, this.props.messages)
             .then(() => {
                 this.workspace.getFlyout().setRecyclingEnabled(false);
                 this.props.vm.refreshWorkspace();
@@ -227,31 +283,41 @@ class Blocks extends React.Component {
             });
     }
 
-    updateToolbox () {
+    updateToolbox() {
         this.toolboxUpdateTimeout = false;
 
         const scale = this.workspace.getFlyout().getWorkspace().scale;
-        const selectedCategoryName = this.workspace.getToolbox().getSelectedItem().getName();
-        const selectedCategoryScrollPosition = this.workspace.getFlyout().getCategoryScrollPosition(
-            selectedCategoryName).y * scale;
-        const offsetWithinCategory = (this.workspace.getFlyout().getWorkspace().getMetrics().viewTop
-            - selectedCategoryScrollPosition);
+        const selectedCategoryName = this.workspace
+            .getToolbox()
+            .getSelectedItem()
+            .getName();
+        const selectedCategoryScrollPosition =
+            this.workspace
+                .getFlyout()
+                .getCategoryScrollPosition(selectedCategoryName).y * scale;
+        const offsetWithinCategory =
+            this.workspace.getFlyout().getWorkspace().getMetrics().viewTop -
+            selectedCategoryScrollPosition;
 
         this.workspace.updateToolbox(this.props.toolboxXML);
         this.workspace.getToolbox().forceRerender();
         this._renderedToolboxXML = this.props.toolboxXML;
 
-        const newCategoryScrollPosition = this.workspace.getFlyout().getCategoryScrollPosition(
-            selectedCategoryName).y * scale;
-        this.workspace.getFlyout().getWorkspace().scrollbar.setY(
-        newCategoryScrollPosition + offsetWithinCategory);
+        const newCategoryScrollPosition =
+            this.workspace
+                .getFlyout()
+                .getCategoryScrollPosition(selectedCategoryName).y * scale;
+        this.workspace
+            .getFlyout()
+            .getWorkspace()
+            .scrollbar.setY(newCategoryScrollPosition + offsetWithinCategory);
 
         const queue = this.toolboxUpdateQueue;
         this.toolboxUpdateQueue = [];
-        queue.forEach(fn => fn());
+        queue.forEach((fn) => fn());
     }
 
-    withToolboxUpdates (fn) {
+    withToolboxUpdates(fn) {
         // if there is a queued toolbox update, we need to wait
         if (this.toolboxUpdateTimeout) {
             this.toolboxUpdateQueue.push(fn);
@@ -260,42 +326,68 @@ class Blocks extends React.Component {
         }
     }
 
-    attachVM () {
+    attachVM() {
         this.workspace.addChangeListener(this.props.vm.blockListener);
-        this.flyoutWorkspace = this.workspace
-            .getFlyout()
-            .getWorkspace();
-        this.flyoutWorkspace.addChangeListener(this.props.vm.flyoutBlockListener);
-        this.flyoutWorkspace.addChangeListener(this.props.vm.monitorBlockListener);
-        this.props.vm.addListener('SCRIPT_GLOW_ON', this.onScriptGlowOn);
-        this.props.vm.addListener('SCRIPT_GLOW_OFF', this.onScriptGlowOff);
-        this.props.vm.addListener('BLOCK_GLOW_ON', this.onBlockGlowOn);
-        this.props.vm.addListener('BLOCK_GLOW_OFF', this.onBlockGlowOff);
-        this.props.vm.addListener('VISUAL_REPORT', this.onVisualReport);
-        this.props.vm.addListener('workspaceUpdate', this.onWorkspaceUpdate);
-        this.props.vm.addListener('targetsUpdate', this.onTargetsUpdate);
-        this.props.vm.addListener('MONITORS_UPDATE', this.handleMonitorsUpdate);
-        this.props.vm.addListener('EXTENSION_ADDED', this.handleExtensionAdded);
-        this.props.vm.addListener('BLOCKSINFO_UPDATE', this.handleBlocksInfoUpdate);
-        this.props.vm.addListener('PERIPHERAL_CONNECTED', this.handleStatusButtonUpdate);
-        this.props.vm.addListener('PERIPHERAL_DISCONNECTED', this.handleStatusButtonUpdate);
+        this.flyoutWorkspace = this.workspace.getFlyout().getWorkspace();
+        this.flyoutWorkspace.addChangeListener(
+            this.props.vm.flyoutBlockListener
+        );
+        this.flyoutWorkspace.addChangeListener(
+            this.props.vm.monitorBlockListener
+        );
+        this.props.vm.addListener("SCRIPT_GLOW_ON", this.onScriptGlowOn);
+        this.props.vm.addListener("SCRIPT_GLOW_OFF", this.onScriptGlowOff);
+        this.props.vm.addListener("BLOCK_GLOW_ON", this.onBlockGlowOn);
+        this.props.vm.addListener("BLOCK_GLOW_OFF", this.onBlockGlowOff);
+        this.props.vm.addListener("VISUAL_REPORT", this.onVisualReport);
+        this.props.vm.addListener("workspaceUpdate", this.onWorkspaceUpdate);
+        this.props.vm.addListener("targetsUpdate", this.onTargetsUpdate);
+        this.props.vm.addListener("MONITORS_UPDATE", this.handleMonitorsUpdate);
+        this.props.vm.addListener("EXTENSION_ADDED", this.handleExtensionAdded);
+        this.props.vm.addListener(
+            "BLOCKSINFO_UPDATE",
+            this.handleBlocksInfoUpdate
+        );
+        this.props.vm.addListener(
+            "PERIPHERAL_CONNECTED",
+            this.handleStatusButtonUpdate
+        );
+        this.props.vm.addListener(
+            "PERIPHERAL_DISCONNECTED",
+            this.handleStatusButtonUpdate
+        );
     }
-    detachVM () {
-        this.props.vm.removeListener('SCRIPT_GLOW_ON', this.onScriptGlowOn);
-        this.props.vm.removeListener('SCRIPT_GLOW_OFF', this.onScriptGlowOff);
-        this.props.vm.removeListener('BLOCK_GLOW_ON', this.onBlockGlowOn);
-        this.props.vm.removeListener('BLOCK_GLOW_OFF', this.onBlockGlowOff);
-        this.props.vm.removeListener('VISUAL_REPORT', this.onVisualReport);
-        this.props.vm.removeListener('workspaceUpdate', this.onWorkspaceUpdate);
-        this.props.vm.removeListener('targetsUpdate', this.onTargetsUpdate);
-        this.props.vm.removeListener('MONITORS_UPDATE', this.handleMonitorsUpdate);
-        this.props.vm.removeListener('EXTENSION_ADDED', this.handleExtensionAdded);
-        this.props.vm.removeListener('BLOCKSINFO_UPDATE', this.handleBlocksInfoUpdate);
-        this.props.vm.removeListener('PERIPHERAL_CONNECTED', this.handleStatusButtonUpdate);
-        this.props.vm.removeListener('PERIPHERAL_DISCONNECTED', this.handleStatusButtonUpdate);
+    detachVM() {
+        this.props.vm.removeListener("SCRIPT_GLOW_ON", this.onScriptGlowOn);
+        this.props.vm.removeListener("SCRIPT_GLOW_OFF", this.onScriptGlowOff);
+        this.props.vm.removeListener("BLOCK_GLOW_ON", this.onBlockGlowOn);
+        this.props.vm.removeListener("BLOCK_GLOW_OFF", this.onBlockGlowOff);
+        this.props.vm.removeListener("VISUAL_REPORT", this.onVisualReport);
+        this.props.vm.removeListener("workspaceUpdate", this.onWorkspaceUpdate);
+        this.props.vm.removeListener("targetsUpdate", this.onTargetsUpdate);
+        this.props.vm.removeListener(
+            "MONITORS_UPDATE",
+            this.handleMonitorsUpdate
+        );
+        this.props.vm.removeListener(
+            "EXTENSION_ADDED",
+            this.handleExtensionAdded
+        );
+        this.props.vm.removeListener(
+            "BLOCKSINFO_UPDATE",
+            this.handleBlocksInfoUpdate
+        );
+        this.props.vm.removeListener(
+            "PERIPHERAL_CONNECTED",
+            this.handleStatusButtonUpdate
+        );
+        this.props.vm.removeListener(
+            "PERIPHERAL_DISCONNECTED",
+            this.handleStatusButtonUpdate
+        );
     }
 
-    updateToolboxBlockValue (id, value) {
+    updateToolboxBlockValue(id, value) {
         this.withToolboxUpdates(() => {
             const block = this.workspace
                 .getFlyout()
@@ -307,15 +399,21 @@ class Blocks extends React.Component {
         });
     }
 
-    onTargetsUpdate () {
+    onTargetsUpdate() {
         if (this.props.vm.editingTarget && this.workspace.getFlyout()) {
-            ['glide', 'move', 'set'].forEach(prefix => {
-                this.updateToolboxBlockValue(`${prefix}x`, Math.round(this.props.vm.editingTarget.x).toString());
-                this.updateToolboxBlockValue(`${prefix}y`, Math.round(this.props.vm.editingTarget.y).toString());
+            ["glide", "move", "set"].forEach((prefix) => {
+                this.updateToolboxBlockValue(
+                    `${prefix}x`,
+                    Math.round(this.props.vm.editingTarget.x).toString()
+                );
+                this.updateToolboxBlockValue(
+                    `${prefix}y`,
+                    Math.round(this.props.vm.editingTarget.y).toString()
+                );
             });
         }
     }
-    onWorkspaceMetricsChange () {
+    onWorkspaceMetricsChange() {
         const target = this.props.vm.editingTarget;
         if (target && target.id) {
             // Dispatch updateMetrics later, since onWorkspaceMetricsChange may be (very indirectly)
@@ -326,32 +424,32 @@ class Blocks extends React.Component {
                     targetID: target.id,
                     scrollX: this.workspace.scrollX,
                     scrollY: this.workspace.scrollY,
-                    scale: this.workspace.scale
+                    scale: this.workspace.scale,
                 });
             }, 0);
         }
     }
-    onScriptGlowOn (data) {
+    onScriptGlowOn(data) {
         this.ScratchBlocks.glowStack(data.id, true);
     }
-    onScriptGlowOff (data) {
+    onScriptGlowOff(data) {
         this.ScratchBlocks.glowStack(data.id, false);
     }
-    onBlockGlowOn (data) {
+    onBlockGlowOn(data) {
         // No-op, support may be added in the future
     }
-    onBlockGlowOff (data) {
+    onBlockGlowOff(data) {
         // No-op, support may be added in the future
     }
-    onVisualReport (data) {
+    onVisualReport(data) {
         this.ScratchBlocks.reportValue(data.id, data.value);
     }
-    getToolboxXML () {
+    getToolboxXML() {
         // Use try/catch because this requires digging pretty deep into the VM
         // Code inside intentionally ignores several error situations (no stage, etc.)
         // Because they would get caught by this try/catch
         try {
-            let {editingTarget: target, runtime} = this.props.vm;
+            let { editingTarget: target, runtime } = this.props.vm;
             const stage = runtime.getTargetForStage();
             if (!target) target = stage; // If no editingTarget, use the stage
 
@@ -362,24 +460,33 @@ class Blocks extends React.Component {
                 this.props.vm.runtime.getBlocksXML(target),
                 this.props.theme
             );
-            return makeToolboxXML(false, target.isStage, target.id, dynamicBlocksXML,
+            return makeToolboxXML(
+                false,
+                target.isStage,
+                target.id,
+                dynamicBlocksXML,
                 targetCostumes[targetCostumes.length - 1].name,
                 stageCostumes[stageCostumes.length - 1].name,
-                targetSounds.length > 0 ? targetSounds[targetSounds.length - 1].name : '',
+                targetSounds.length > 0
+                    ? targetSounds[targetSounds.length - 1].name
+                    : "",
                 getColorsForTheme(this.props.theme)
             );
         } catch {
             return null;
         }
     }
-    onWorkspaceUpdate (data) {
+    onWorkspaceUpdate(data) {
         // When we change sprites, update the toolbox to have the new sprite's blocks
         const toolboxXML = this.getToolboxXML();
         if (toolboxXML) {
             this.props.updateToolboxState(toolboxXML);
         }
 
-        if (this.props.vm.editingTarget && !this.props.workspaceMetrics.targets[this.props.vm.editingTarget.id]) {
+        if (
+            this.props.vm.editingTarget &&
+            !this.props.workspaceMetrics.targets[this.props.vm.editingTarget.id]
+        ) {
             this.onWorkspaceMetricsChange();
         }
 
@@ -387,7 +494,10 @@ class Blocks extends React.Component {
         this.workspace.removeChangeListener(this.props.vm.blockListener);
         const dom = this.ScratchBlocks.utils.xml.textToDom(data.xml);
         try {
-            this.ScratchBlocks.Xml.clearWorkspaceAndLoadFromXml(dom, this.workspace);
+            this.ScratchBlocks.Xml.clearWorkspaceAndLoadFromXml(
+                dom,
+                this.workspace
+            );
         } catch (error) {
             // The workspace is likely incomplete. What did update should be
             // functional.
@@ -405,8 +515,14 @@ class Blocks extends React.Component {
         }
         this.workspace.addChangeListener(this.props.vm.blockListener);
 
-        if (this.props.vm.editingTarget && this.props.workspaceMetrics.targets[this.props.vm.editingTarget.id]) {
-            const {scrollX, scrollY, scale} = this.props.workspaceMetrics.targets[this.props.vm.editingTarget.id];
+        if (
+            this.props.vm.editingTarget &&
+            this.props.workspaceMetrics.targets[this.props.vm.editingTarget.id]
+        ) {
+            const { scrollX, scrollY, scale } =
+                this.props.workspaceMetrics.targets[
+                    this.props.vm.editingTarget.id
+                ];
             this.workspace.scrollX = scrollX;
             this.workspace.scrollY = scrollY;
             this.workspace.scale = scale;
@@ -418,14 +534,14 @@ class Blocks extends React.Component {
         // workspace to be 'undone' here.
         this.workspace.clearUndo();
     }
-    handleMonitorsUpdate (monitors) {
+    handleMonitorsUpdate(monitors) {
         // Update the checkboxes of the relevant monitors.
         // TODO: What about monitors that have fields? See todo in scratch-vm blocks.js changeBlock:
         // https://github.com/LLK/scratch-vm/blob/2373f9483edaf705f11d62662f7bb2a57fbb5e28/src/engine/blocks.js#L569-L576
         const flyout = this.workspace.getFlyout();
         for (const monitor of monitors.values()) {
-            const blockId = monitor.get('id');
-            const isVisible = monitor.get('visible');
+            const blockId = monitor.get("id");
+            const isVisible = monitor.get("visible");
             flyout.setCheckboxState(blockId, isVisible);
             // We also need to update the isMonitored flag for this block on the VM, since it's used to determine
             // whether the checkbox is activated or not when the checkbox is re-displayed (e.g. local variables/blocks
@@ -436,28 +552,37 @@ class Blocks extends React.Component {
             }
         }
     }
-    handleExtensionAdded (categoryInfo) {
-        const defineBlocks = blockInfoArray => {
+    handleExtensionAdded(categoryInfo) {
+        const defineBlocks = (blockInfoArray) => {
             if (blockInfoArray && blockInfoArray.length > 0) {
                 const staticBlocksJson = [];
                 const dynamicBlocksInfo = [];
-                blockInfoArray.forEach(blockInfo => {
+                blockInfoArray.forEach((blockInfo) => {
                     if (blockInfo.info && blockInfo.info.isDynamic) {
                         dynamicBlocksInfo.push(blockInfo);
                     } else if (blockInfo.json) {
-                        staticBlocksJson.push(injectExtensionBlockTheme(blockInfo.json, this.props.theme));
+                        staticBlocksJson.push(
+                            injectExtensionBlockTheme(
+                                blockInfo.json,
+                                this.props.theme
+                            )
+                        );
                     }
                     // otherwise it's a non-block entry such as '---'
                 });
 
                 this.ScratchBlocks.defineBlocksWithJsonArray(staticBlocksJson);
-                dynamicBlocksInfo.forEach(blockInfo => {
+                dynamicBlocksInfo.forEach((blockInfo) => {
                     // This is creating the block factory / constructor -- NOT a specific instance of the block.
                     // The factory should only know static info about the block: the category info and the opcode.
                     // Anything else will be picked up from the XML attached to the block instance.
                     const extendedOpcode = `${categoryInfo.id}_${blockInfo.info.opcode}`;
-                    const blockDefinition =
-                        defineDynamicBlock(this.ScratchBlocks, categoryInfo, blockInfo, extendedOpcode);
+                    const blockDefinition = defineDynamicBlock(
+                        this.ScratchBlocks,
+                        categoryInfo,
+                        blockInfo,
+                        extendedOpcode
+                    );
                     this.ScratchBlocks.Blocks[extendedOpcode] = blockDefinition;
                 });
             }
@@ -466,8 +591,12 @@ class Blocks extends React.Component {
         // scratch-blocks implements a menu or custom field as a special kind of block ("shadow" block)
         // these actually define blocks and MUST run regardless of the UI state
         defineBlocks(
-            Object.getOwnPropertyNames(categoryInfo.customFieldTypes)
-                .map(fieldTypeName => categoryInfo.customFieldTypes[fieldTypeName].scratchBlocksDefinition));
+            Object.getOwnPropertyNames(categoryInfo.customFieldTypes).map(
+                (fieldTypeName) =>
+                    categoryInfo.customFieldTypes[fieldTypeName]
+                        .scratchBlocksDefinition
+            )
+        );
         defineBlocks(categoryInfo.menus);
         defineBlocks(categoryInfo.blocks);
 
@@ -477,12 +606,14 @@ class Blocks extends React.Component {
             this.props.updateToolboxState(toolboxXML);
         }
     }
-    handleBlocksInfoUpdate (categoryInfo) {
+    handleBlocksInfoUpdate(categoryInfo) {
         // @todo Later we should replace this to avoid all the warnings from redefining blocks.
         this.handleExtensionAdded(categoryInfo);
     }
-    handleCategorySelected (categoryId) {
-        const extension = extensionData.find(ext => ext.extensionId === categoryId);
+    handleCategorySelected(categoryId) {
+        const extension = extensionData.find(
+            (ext) => ext.extensionId === categoryId
+        );
         if (extension && extension.launchPeripheralConnectionFlow) {
             this.handleConnectionModalStart(categoryId);
         }
@@ -492,29 +623,35 @@ class Blocks extends React.Component {
             toolbox.setSelectedItem(toolbox.getToolboxItemById(categoryId));
         });
     }
-    setBlocks (blocks) {
+    setBlocks(blocks) {
         this.blocks = blocks;
     }
-    handlePromptStart (message, defaultValue, callback, optTitle, optVarType) {
-        const p = {prompt: {callback, message, defaultValue}};
-        p.prompt.title = optTitle ? optTitle :
-            this.ScratchBlocks.Msg.VARIABLE_MODAL_TITLE;
-        p.prompt.varType = typeof optVarType === 'string' ?
-            optVarType : this.ScratchBlocks.SCALAR_VARIABLE_TYPE;
+    handlePromptStart(message, defaultValue, callback, optTitle, optVarType) {
+        const p = { prompt: { callback, message, defaultValue } };
+        p.prompt.title = optTitle
+            ? optTitle
+            : this.ScratchBlocks.Msg.VARIABLE_MODAL_TITLE;
+        p.prompt.varType =
+            typeof optVarType === "string"
+                ? optVarType
+                : this.ScratchBlocks.SCALAR_VARIABLE_TYPE;
         p.prompt.showVariableOptions = // This flag means that we should show variable/list options about scope
             optVarType !== this.ScratchBlocks.BROADCAST_MESSAGE_VARIABLE_TYPE &&
-            p.prompt.title !== this.ScratchBlocks.Msg.RENAME_VARIABLE_MODAL_TITLE &&
+            p.prompt.title !==
+                this.ScratchBlocks.Msg.RENAME_VARIABLE_MODAL_TITLE &&
             p.prompt.title !== this.ScratchBlocks.Msg.RENAME_LIST_MODAL_TITLE;
-        p.prompt.showCloudOption = (optVarType === this.ScratchBlocks.SCALAR_VARIABLE_TYPE) && this.props.canUseCloud;
+        p.prompt.showCloudOption =
+            optVarType === this.ScratchBlocks.SCALAR_VARIABLE_TYPE &&
+            this.props.canUseCloud;
         this.setState(p);
     }
-    handleConnectionModalStart (extensionId) {
+    handleConnectionModalStart(extensionId) {
         this.props.onOpenConnectionModal(extensionId);
     }
-    handleStatusButtonUpdate () {
+    handleStatusButtonUpdate() {
         this.ScratchBlocks.refreshStatusButtons(this.workspace);
     }
-    handleOpenSoundRecorder () {
+    handleOpenSoundRecorder() {
         this.props.onOpenSoundRecorder();
     }
 
@@ -523,32 +660,40 @@ class Blocks extends React.Component {
      * and additional potentially conflicting variable names from the VM
      * to the variable validation prompt callback used in scratch-blocks.
      */
-    handlePromptCallback (input, variableOptions) {
+    handlePromptCallback(input, variableOptions) {
         this.state.prompt.callback(
             input,
-            this.props.vm.runtime.getAllVarNamesOfType(this.state.prompt.varType),
-            variableOptions);
+            this.props.vm.runtime.getAllVarNamesOfType(
+                this.state.prompt.varType
+            ),
+            variableOptions
+        );
         this.handlePromptClose();
     }
-    handlePromptClose () {
-        this.setState({prompt: null});
+    handlePromptClose() {
+        this.setState({ prompt: null });
     }
-    handleCustomProceduresClose (data) {
+    handleCustomProceduresClose(data) {
         this.props.onRequestCloseCustomProcedures(data);
         const ws = this.workspace;
         this.updateToolbox();
-        ws.getToolbox().selectCategoryByName('myBlocks');
+        ws.getToolbox().selectCategoryByName("myBlocks");
     }
-    handleDrop (dragInfo) {
+    handleDrop(dragInfo) {
         fetch(dragInfo.payload.bodyUrl)
-            .then(response => response.json())
-            .then(blocks => this.props.vm.shareBlocksToTarget(blocks, this.props.vm.editingTarget.id))
+            .then((response) => response.json())
+            .then((blocks) =>
+                this.props.vm.shareBlocksToTarget(
+                    blocks,
+                    this.props.vm.editingTarget.id
+                )
+            )
             .then(() => {
                 this.props.vm.refreshWorkspace();
                 this.updateToolbox(); // To show new variables/custom blocks
             });
     }
-    render () {
+    render() {
         /* eslint-disable no-unused-vars */
         const {
             anyModalVisible,
@@ -585,10 +730,15 @@ class Blocks extends React.Component {
                     <Prompt
                         defaultValue={this.state.prompt.defaultValue}
                         isStage={vm.runtime.getEditingTarget().isStage}
-                        showListMessage={this.state.prompt.varType === this.ScratchBlocks.LIST_VARIABLE_TYPE}
+                        showListMessage={
+                            this.state.prompt.varType ===
+                            this.ScratchBlocks.LIST_VARIABLE_TYPE
+                        }
                         label={this.state.prompt.message}
                         showCloudOption={this.state.prompt.showCloudOption}
-                        showVariableOptions={this.state.prompt.showVariableOptions}
+                        showVariableOptions={
+                            this.state.prompt.showVariableOptions
+                        }
                         title={this.state.prompt.title}
                         vm={vm}
                         onCancel={this.handlePromptClose}
@@ -605,7 +755,7 @@ class Blocks extends React.Component {
                 {customProceduresVisible ? (
                     <CustomProcedures
                         options={{
-                            media: options.media
+                            media: options.media,
                         }}
                         onRequestClose={this.handleCustomProceduresClose}
                     />
@@ -635,10 +785,10 @@ Blocks.propTypes = {
         zoom: PropTypes.shape({
             controls: PropTypes.bool,
             wheel: PropTypes.bool,
-            startScale: PropTypes.number
+            startScale: PropTypes.number,
         }),
         comments: PropTypes.bool,
-        collapse: PropTypes.bool
+        collapse: PropTypes.bool,
     }),
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,
     theme: PropTypes.oneOf(Object.keys(themeMap)),
@@ -648,23 +798,23 @@ Blocks.propTypes = {
     useCatBlocks: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired,
     workspaceMetrics: PropTypes.shape({
-        targets: PropTypes.objectOf(PropTypes.object)
-    })
+        targets: PropTypes.objectOf(PropTypes.object),
+    }),
 };
 
 Blocks.defaultOptions = {
     zoom: {
         controls: true,
         wheel: false,
-        startScale: BLOCKS_DEFAULT_SCALE
+        startScale: BLOCKS_DEFAULT_SCALE,
     },
     move: {
-      wheel: true,
+        wheel: true,
     },
     grid: {
         spacing: 40,
         length: 2,
-        colour: '#ddd'
+        colour: "#ddd",
     },
     comments: true,
     collapse: false,
@@ -675,14 +825,14 @@ Blocks.defaultOptions = {
 Blocks.defaultProps = {
     isVisible: true,
     options: Blocks.defaultOptions,
-    theme: DEFAULT_THEME
+    theme: DEFAULT_THEME,
 };
 
-const mapStateToProps = state => ({
-    anyModalVisible: (
-        Object.keys(state.scratchGui.modals).some(key => state.scratchGui.modals[key]) ||
-        state.scratchGui.mode.isFullScreen
-    ),
+const mapStateToProps = (state) => ({
+    anyModalVisible:
+        Object.keys(state.scratchGui.modals).some(
+            (key) => state.scratchGui.modals[key]
+        ) || state.scratchGui.mode.isFullScreen,
     extensionLibraryVisible: state.scratchGui.modals.extensionLibrary,
     isRtl: state.locales.isRtl,
     locale: state.locales.locale,
@@ -690,13 +840,15 @@ const mapStateToProps = state => ({
     toolboxXML: state.scratchGui.toolbox.toolboxXML,
     customProceduresVisible: state.scratchGui.customProcedures.active,
     workspaceMetrics: state.scratchGui.workspaceMetrics,
-    useCatBlocks: isTimeTravel2020(state)
+    useCatBlocks: isTimeTravel2020(state),
 });
 
-const mapDispatchToProps = dispatch => ({
-    onActivateColorPicker: callback => dispatch(activateColorPicker(callback)),
-    onActivateCustomProcedures: (data, callback) => dispatch(activateCustomProcedures(data, callback)),
-    onOpenConnectionModal: id => {
+const mapDispatchToProps = (dispatch) => ({
+    onActivateColorPicker: (callback) =>
+        dispatch(activateColorPicker(callback)),
+    onActivateCustomProcedures: (data, callback) =>
+        dispatch(activateCustomProcedures(data, callback)),
+    onOpenConnectionModal: (id) => {
         dispatch(setConnectionModalExtensionId(id));
         dispatch(openConnectionModal());
     },
@@ -707,20 +859,17 @@ const mapDispatchToProps = dispatch => ({
     onRequestCloseExtensionLibrary: () => {
         dispatch(closeExtensionLibrary());
     },
-    onRequestCloseCustomProcedures: data => {
+    onRequestCloseCustomProcedures: (data) => {
         dispatch(deactivateCustomProcedures(data));
     },
-    updateToolboxState: toolboxXML => {
+    updateToolboxState: (toolboxXML) => {
         dispatch(updateToolbox(toolboxXML));
     },
-    updateMetrics: metrics => {
+    updateMetrics: (metrics) => {
         dispatch(updateMetrics(metrics));
-    }
+    },
 });
 
-export default errorBoundaryHOC('Blocks')(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps
-    )(Blocks)
+export default errorBoundaryHOC("Blocks")(
+    connect(mapStateToProps, mapDispatchToProps)(Blocks)
 );

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -137,9 +137,22 @@ class Blocks extends React.Component {
             workspaceConfig
         );
         this.workspace.registerToolboxCategoryCallback(
+            "VARIABLE",
+            this.ScratchBlocks.ScratchVariables.getVariablesCategory
+        );
+        this.workspace.registerToolboxCategoryCallback(
             "PROCEDURE",
             this.ScratchBlocks.ScratchProcedures.getProceduresCategory
         );
+        this.workspace.addChangeListener((event) => {
+            if (
+                event.type === this.ScratchBlocks.Events.VAR_CREATE ||
+                event.type === this.ScratchBlocks.Events.VAR_RENAME ||
+                event.type === this.ScratchBlocks.Events.VAR_DELETE
+            ) {
+                this.requestToolboxUpdate();
+            }
+        });
 
         // Register buttons under new callback keys for creating variables,
         // lists, and procedures from extensions.
@@ -147,7 +160,7 @@ class Blocks extends React.Component {
         const toolboxWorkspace = this.workspace.getFlyout().getWorkspace();
 
         const varListButtonCallback = (type) => () =>
-            this.ScratchBlocks.Variables.createVariable(
+            this.ScratchBlocks.ScratchVariables.createVariable(
                 this.workspace,
                 null,
                 type


### PR DESCRIPTION
This PR updates scratch-gui to use the custom variable support introduced in scratch-blocks in a series of recent PRs.