### PR TITLE
fix: specify the function to be used for prompting about variables

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -90,6 +90,9 @@ class Blocks extends React.Component {
             "setLocale",
         ]);
         this.ScratchBlocks.dialog.setPrompt(this.handlePromptStart);
+        this.ScratchBlocks.ScratchVariables.setPromptHandler(
+            this.handlePromptStart
+        );
         this.ScratchBlocks.statusButtonCallback =
             this.handleConnectionModalStart;
         this.ScratchBlocks.recordSoundCallback = this.handleOpenSoundRecorder;


### PR DESCRIPTION
This PR uses the method introduced in https://github.com/gonfunko/scratch-blocks/pull/106 to specify the function in scratch-gui that scratch-blocks should use when prompting the user about creating or renaming variables.