### PR TITLE
fix: update the toolbox in response to procedure deletion/creation

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -151,7 +151,11 @@ class Blocks extends React.Component {
             if (
                 event.type === this.ScratchBlocks.Events.VAR_CREATE ||
                 event.type === this.ScratchBlocks.Events.VAR_RENAME ||
-                event.type === this.ScratchBlocks.Events.VAR_DELETE
+                event.type === this.ScratchBlocks.Events.VAR_DELETE ||
+                (event.type === this.ScratchBlocks.Events.BLOCK_DELETE &&
+                    event.oldJson.type === "procedures_definition") ||
+                (event.type === this.ScratchBlocks.Events.BLOCK_CREATE &&
+                    event.json.type === "procedures_definition")
             ) {
                 this.requestToolboxUpdate();
             }


### PR DESCRIPTION
In conjunction with https://github.com/gonfunko/scratch-blocks/pull/107, this PR updates the toolbox to remove custom block/procedure call blocks when the custom block/procedure is deleted. It also fixes https://github.com/scratchfoundation/scratch-blocks/issues/2010 and https://github.com/scratchfoundation/scratch-blocks/issues/1982 from upstream Scratch where undoing a procedure/custom block definition did not readd the caller block to the toolbox.