### PR TITLE
fix: only refresh the toolbox when procedures are created via undo

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -151,7 +151,12 @@ class Blocks extends React.Component {
             if (
                 event.type === this.ScratchBlocks.Events.VAR_CREATE ||
                 event.type === this.ScratchBlocks.Events.VAR_RENAME ||
-                event.type === this.ScratchBlocks.Events.VAR_DELETE
+                event.type === this.ScratchBlocks.Events.VAR_DELETE ||
+                (event.type === this.ScratchBlocks.Events.BLOCK_DELETE &&
+                    event.oldJson.type === "procedures_definition") ||
+                (event.type === this.ScratchBlocks.Events.BLOCK_CREATE &&
+                    event.json.type === "procedures_definition" &&
+                    !event.recordUndo)
             ) {
                 this.requestToolboxUpdate();
             }

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -154,6 +154,9 @@ class Blocks extends React.Component {
                 event.type === this.ScratchBlocks.Events.VAR_DELETE ||
                 (event.type === this.ScratchBlocks.Events.BLOCK_DELETE &&
                     event.oldJson.type === "procedures_definition") ||
+                // Only refresh the toolbox when procedure block creations are
+                // triggered by undoing a deletion (implied by recordUndo being
+                // false on the event).
                 (event.type === this.ScratchBlocks.Events.BLOCK_CREATE &&
                     event.json.type === "procedures_definition" &&
                     !event.recordUndo)


### PR DESCRIPTION
This PR restricts toolbox refreshes to only occur when a procedure block is creating via undoing a deletion, vs any time one is created. This is both more efficient and also helps fix the positioning of newly created procedure blocks.