### PR TITLE
chore: don't specify the renderer/theme

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -119,10 +119,6 @@ class Blocks extends React.Component {
             this.props.onActivateCustomProcedures;
         this.ScratchBlocks.ScratchMsgs.setLocale(this.props.locale);
 
-        const theme = this.ScratchBlocks.Theme.defineTheme("Scratch", {
-            base: this.ScratchBlocks.Themes.Zelos,
-            startHats: true,
-        });
         const workspaceConfig = defaultsDeep(
             {},
             Blocks.defaultOptions,
@@ -131,8 +127,6 @@ class Blocks extends React.Component {
                 rtl: this.props.isRtl,
                 toolbox: this.props.toolboxXML,
                 colours: getColorsForTheme(this.props.theme),
-                renderer: "zelos",
-                theme: theme,
             }
         );
         this.workspace = this.ScratchBlocks.inject(


### PR DESCRIPTION
This PR stops specifying the renderer/theme in scratch-gui since these are now specified in scratch-blocks instead.