### PR TITLE
fix: make dropdown menu shadow block colors consistent

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -5,126 +5,164 @@
  * @return {ScratchBlocks} ScratchBlocks connected with the vm
  */
 export default function (vm, useCatBlocks) {
-    const {ScratchBlocks} = useCatBlocks ? require('cat-blocks') : require('scratch-blocks');
+    const { ScratchBlocks } = useCatBlocks
+        ? require("cat-blocks")
+        : require("scratch-blocks");
     const jsonForMenuBlock = function (name, menuOptionsFn, colors, start) {
         return {
-            message0: '%1',
+            message0: "%1",
             args0: [
                 {
-                    type: 'field_dropdown',
+                    type: "field_dropdown",
                     name: name,
                     options: function () {
                         return start.concat(menuOptionsFn());
-                    }
-                }
+                    },
+                },
             ],
             inputsInline: true,
-            output: 'String',
+            output: "String",
             colour: colors.secondary,
             colourSecondary: colors.secondary,
             colourTertiary: colors.tertiary,
             colourQuaternary: colors.quaternary,
-            outputShape: ScratchBlocks.OUTPUT_SHAPE_ROUND
+            outputShape: ScratchBlocks.OUTPUT_SHAPE_ROUND,
         };
     };
 
-    const jsonForHatBlockMenu = function (hatName, name, menuOptionsFn, colors, start) {
+    const jsonForHatBlockMenu = function (
+        hatName,
+        name,
+        menuOptionsFn,
+        colors,
+        start
+    ) {
         return {
             message0: hatName,
             args0: [
                 {
-                    type: 'field_dropdown',
+                    type: "field_dropdown",
                     name: name,
                     options: function () {
                         return start.concat(menuOptionsFn());
-                    }
-                }
+                    },
+                },
             ],
             colour: colors.primary,
             colourSecondary: colors.secondary,
             colourTertiary: colors.tertiary,
             colourQuaternary: colors.quaternary,
-            extensions: ['shape_hat']
+            extensions: ["shape_hat"],
         };
     };
-
 
     const jsonForSensingMenus = function (menuOptionsFn) {
         return {
             message0: ScratchBlocks.Msg.SENSING_OF,
             args0: [
                 {
-                    type: 'field_dropdown',
-                    name: 'PROPERTY',
+                    type: "field_dropdown",
+                    name: "PROPERTY",
                     options: function () {
                         return menuOptionsFn();
-                    }
-
+                    },
                 },
                 {
-                    type: 'input_value',
-                    name: 'OBJECT'
-                }
+                    type: "input_value",
+                    name: "OBJECT",
+                },
             ],
             output: true,
             colour: ScratchBlocks.Colours.sensing.primary,
             colourSecondary: ScratchBlocks.Colours.sensing.secondary,
             colourTertiary: ScratchBlocks.Colours.sensing.tertiary,
             colourQuaternary: ScratchBlocks.Colours.sensing.quaternary,
-            outputShape: ScratchBlocks.OUTPUT_SHAPE_ROUND
+            outputShape: ScratchBlocks.OUTPUT_SHAPE_ROUND,
         };
     };
 
     const soundsMenu = function () {
-        let menu = [['', '']];
+        let menu = [["", ""]];
         if (vm.editingTarget && vm.editingTarget.sprite.sounds.length > 0) {
-            menu = vm.editingTarget.sprite.sounds.map(sound => [sound.name, sound.name]);
+            menu = vm.editingTarget.sprite.sounds.map((sound) => [
+                sound.name,
+                sound.name,
+            ]);
         }
         menu.push([
-            ScratchBlocks.ScratchMsgs.translate('SOUND_RECORD', 'record...'),
-            'SOUND_RECORD'
+            ScratchBlocks.ScratchMsgs.translate("SOUND_RECORD", "record..."),
+            "SOUND_RECORD",
         ]);
         return menu;
     };
 
     const costumesMenu = function () {
         if (vm.editingTarget && vm.editingTarget.getCostumes().length > 0) {
-            return vm.editingTarget.getCostumes().map(costume => [costume.name, costume.name]);
+            return vm.editingTarget
+                .getCostumes()
+                .map((costume) => [costume.name, costume.name]);
         }
-        return [['', '']];
+        return [["", ""]];
     };
 
     const backdropsMenu = function () {
-        const next = ScratchBlocks.ScratchMsgs.translate('LOOKS_NEXTBACKDROP', 'next backdrop');
-        const previous = ScratchBlocks.ScratchMsgs.translate('LOOKS_PREVIOUSBACKDROP', 'previous backdrop');
-        const random = ScratchBlocks.ScratchMsgs.translate('LOOKS_RANDOMBACKDROP', 'random backdrop');
-        if (vm.runtime.targets[0] && vm.runtime.targets[0].getCostumes().length > 0) {
-            return vm.runtime.targets[0].getCostumes().map(costume => [costume.name, costume.name])
-                .concat([[next, 'next backdrop'],
-                    [previous, 'previous backdrop'],
-                    [random, 'random backdrop']]);
+        const next = ScratchBlocks.ScratchMsgs.translate(
+            "LOOKS_NEXTBACKDROP",
+            "next backdrop"
+        );
+        const previous = ScratchBlocks.ScratchMsgs.translate(
+            "LOOKS_PREVIOUSBACKDROP",
+            "previous backdrop"
+        );
+        const random = ScratchBlocks.ScratchMsgs.translate(
+            "LOOKS_RANDOMBACKDROP",
+            "random backdrop"
+        );
+        if (
+            vm.runtime.targets[0] &&
+            vm.runtime.targets[0].getCostumes().length > 0
+        ) {
+            return vm.runtime.targets[0]
+                .getCostumes()
+                .map((costume) => [costume.name, costume.name])
+                .concat([
+                    [next, "next backdrop"],
+                    [previous, "previous backdrop"],
+                    [random, "random backdrop"],
+                ]);
         }
-        return [['', '']];
+        return [["", ""]];
     };
 
     const backdropNamesMenu = function () {
         const stage = vm.runtime.getTargetForStage();
         if (stage && stage.getCostumes().length > 0) {
-            return stage.getCostumes().map(costume => [costume.name, costume.name]);
+            return stage
+                .getCostumes()
+                .map((costume) => [costume.name, costume.name]);
         }
-        return [['', '']];
+        return [["", ""]];
     };
 
     const spriteMenu = function () {
         const sprites = [];
         for (const targetId in vm.runtime.targets) {
-            if (!Object.prototype.hasOwnProperty.call(vm.runtime.targets, targetId)) continue;
+            if (
+                !Object.prototype.hasOwnProperty.call(
+                    vm.runtime.targets,
+                    targetId
+                )
+            )
+                continue;
             if (vm.runtime.targets[targetId].isOriginal) {
                 if (!vm.runtime.targets[targetId].isStage) {
                     if (vm.runtime.targets[targetId] === vm.editingTarget) {
                         continue;
                     }
-                    sprites.push([vm.runtime.targets[targetId].sprite.name, vm.runtime.targets[targetId].sprite.name]);
+                    sprites.push([
+                        vm.runtime.targets[targetId].sprite.name,
+                        vm.runtime.targets[targetId].sprite.name,
+                    ]);
                 }
             }
         }
@@ -135,12 +173,15 @@ export default function (vm, useCatBlocks) {
         if (vm.editingTarget && vm.editingTarget.isStage) {
             const menu = spriteMenu();
             if (menu.length === 0) {
-                return [['', '']]; // Empty menu matches Scratch 2 behavior
+                return [["", ""]]; // Empty menu matches Scratch 2 behavior
             }
             return menu;
         }
-        const myself = ScratchBlocks.ScratchMsgs.translate('CONTROL_CREATECLONEOF_MYSELF', 'myself');
-        return [[myself, '_myself_']].concat(spriteMenu());
+        const myself = ScratchBlocks.ScratchMsgs.translate(
+            "CONTROL_CREATECLONEOF_MYSELF",
+            "myself"
+        );
+        return [[myself, "_myself_"]].concat(spriteMenu());
     };
 
     const soundColors = ScratchBlocks.Colours.sounds;
@@ -156,69 +197,107 @@ export default function (vm, useCatBlocks) {
     const eventColors = ScratchBlocks.Colours.event;
 
     ScratchBlocks.Blocks.sound_sounds_menu.init = function () {
-        const json = jsonForMenuBlock('SOUND_MENU', soundsMenu, soundColors, []);
+        const json = jsonForMenuBlock(
+            "SOUND_MENU",
+            soundsMenu,
+            soundColors,
+            []
+        );
         this.jsonInit(json);
-        this.inputList[0].removeField('SOUND_MENU');
-        this.inputList[0].appendField(new ScratchBlocks.FieldDropdown(() => {
-            return soundsMenu();
-        }, (newValue) => {
-            if (newValue === 'SOUND_RECORD') {
-                  ScratchBlocks.recordSoundCallback();
-                  return null;
-            }
-            return newValue;
-        }), 'SOUND_MENU');
+        this.inputList[0].removeField("SOUND_MENU");
+        this.inputList[0].appendField(
+            new ScratchBlocks.FieldDropdown(
+                () => {
+                    return soundsMenu();
+                },
+                (newValue) => {
+                    if (newValue === "SOUND_RECORD") {
+                        ScratchBlocks.recordSoundCallback();
+                        return null;
+                    }
+                    return newValue;
+                }
+            ),
+            "SOUND_MENU"
+        );
     };
 
     ScratchBlocks.Blocks.looks_costume.init = function () {
-        const json = jsonForMenuBlock('COSTUME', costumesMenu, looksColors, []);
+        const json = jsonForMenuBlock("COSTUME", costumesMenu, looksColors, []);
         this.jsonInit(json);
     };
 
     ScratchBlocks.Blocks.looks_backdrops.init = function () {
-        const json = jsonForMenuBlock('BACKDROP', backdropsMenu, looksColors, []);
+        const json = jsonForMenuBlock(
+            "BACKDROP",
+            backdropsMenu,
+            looksColors,
+            []
+        );
         this.jsonInit(json);
     };
 
     ScratchBlocks.Blocks.event_whenbackdropswitchesto.init = function () {
         const json = jsonForHatBlockMenu(
             ScratchBlocks.Msg.EVENT_WHENBACKDROPSWITCHESTO,
-            'BACKDROP', backdropNamesMenu, eventColors, []);
+            "BACKDROP",
+            backdropNamesMenu,
+            eventColors,
+            []
+        );
         this.jsonInit(json);
     };
 
     ScratchBlocks.Blocks.motion_pointtowards_menu.init = function () {
-        const mouse = ScratchBlocks.ScratchMsgs.translate('MOTION_POINTTOWARDS_POINTER', 'mouse-pointer');
-        const json = jsonForMenuBlock('TOWARDS', spriteMenu, motionColors, [
-            [mouse, '_mouse_']
+        const mouse = ScratchBlocks.ScratchMsgs.translate(
+            "MOTION_POINTTOWARDS_POINTER",
+            "mouse-pointer"
+        );
+        const json = jsonForMenuBlock("TOWARDS", spriteMenu, motionColors, [
+            [mouse, "_mouse_"],
         ]);
         this.jsonInit(json);
     };
 
     ScratchBlocks.Blocks.motion_goto_menu.init = function () {
-        const random = ScratchBlocks.ScratchMsgs.translate('MOTION_GOTO_RANDOM', 'random position');
-        const mouse = ScratchBlocks.ScratchMsgs.translate('MOTION_GOTO_POINTER', 'mouse-pointer');
-        const json = jsonForMenuBlock('TO', spriteMenu, motionColors, [
-            [random, '_random_'],
-            [mouse, '_mouse_']
+        const random = ScratchBlocks.ScratchMsgs.translate(
+            "MOTION_GOTO_RANDOM",
+            "random position"
+        );
+        const mouse = ScratchBlocks.ScratchMsgs.translate(
+            "MOTION_GOTO_POINTER",
+            "mouse-pointer"
+        );
+        const json = jsonForMenuBlock("TO", spriteMenu, motionColors, [
+            [random, "_random_"],
+            [mouse, "_mouse_"],
         ]);
         this.jsonInit(json);
     };
 
     ScratchBlocks.Blocks.motion_glideto_menu.init = function () {
-        const random = ScratchBlocks.ScratchMsgs.translate('MOTION_GLIDETO_RANDOM', 'random position');
-        const mouse = ScratchBlocks.ScratchMsgs.translate('MOTION_GLIDETO_POINTER', 'mouse-pointer');
-        const json = jsonForMenuBlock('TO', spriteMenu, motionColors, [
-            [random, '_random_'],
-            [mouse, '_mouse_']
+        const random = ScratchBlocks.ScratchMsgs.translate(
+            "MOTION_GLIDETO_RANDOM",
+            "random position"
+        );
+        const mouse = ScratchBlocks.ScratchMsgs.translate(
+            "MOTION_GLIDETO_POINTER",
+            "mouse-pointer"
+        );
+        const json = jsonForMenuBlock("TO", spriteMenu, motionColors, [
+            [random, "_random_"],
+            [mouse, "_mouse_"],
         ]);
         this.jsonInit(json);
     };
 
     ScratchBlocks.Blocks.sensing_of_object_menu.init = function () {
-        const stage = ScratchBlocks.ScratchMsgs.translate('SENSING_OF_STAGE', 'Stage');
-        const json = jsonForMenuBlock('OBJECT', spriteMenu, sensingColors, [
-            [stage, '_stage_']
+        const stage = ScratchBlocks.ScratchMsgs.translate(
+            "SENSING_OF_STAGE",
+            "Stage"
+        );
+        const json = jsonForMenuBlock("OBJECT", spriteMenu, sensingColors, [
+            [stage, "_stage_"],
         ]);
         this.jsonInit(json);
     };
@@ -230,7 +309,7 @@ export default function (vm, useCatBlocks) {
         // Get the sensing_of block from vm.
         let defaultSensingOfBlock;
         const blocks = vm.runtime.flyoutBlocks._blocks;
-        Object.keys(blocks).forEach(id => {
+        Object.keys(blocks).forEach((id) => {
             const block = blocks[id];
             if (id === blockType || (block && block.opcode === blockType)) {
                 defaultSensingOfBlock = block;
@@ -241,18 +320,18 @@ export default function (vm, useCatBlocks) {
         // Called every time it opens since it depends on the values in the other block input.
         const menuFn = function () {
             const stageOptions = [
-                [ScratchBlocks.Msg.SENSING_OF_BACKDROPNUMBER, 'backdrop #'],
-                [ScratchBlocks.Msg.SENSING_OF_BACKDROPNAME, 'backdrop name'],
-                [ScratchBlocks.Msg.SENSING_OF_VOLUME, 'volume']
+                [ScratchBlocks.Msg.SENSING_OF_BACKDROPNUMBER, "backdrop #"],
+                [ScratchBlocks.Msg.SENSING_OF_BACKDROPNAME, "backdrop name"],
+                [ScratchBlocks.Msg.SENSING_OF_VOLUME, "volume"],
             ];
             const spriteOptions = [
-                [ScratchBlocks.Msg.SENSING_OF_XPOSITION, 'x position'],
-                [ScratchBlocks.Msg.SENSING_OF_YPOSITION, 'y position'],
-                [ScratchBlocks.Msg.SENSING_OF_DIRECTION, 'direction'],
-                [ScratchBlocks.Msg.SENSING_OF_COSTUMENUMBER, 'costume #'],
-                [ScratchBlocks.Msg.SENSING_OF_COSTUMENAME, 'costume name'],
-                [ScratchBlocks.Msg.SENSING_OF_SIZE, 'size'],
-                [ScratchBlocks.Msg.SENSING_OF_VOLUME, 'volume']
+                [ScratchBlocks.Msg.SENSING_OF_XPOSITION, "x position"],
+                [ScratchBlocks.Msg.SENSING_OF_YPOSITION, "y position"],
+                [ScratchBlocks.Msg.SENSING_OF_DIRECTION, "direction"],
+                [ScratchBlocks.Msg.SENSING_OF_COSTUMENUMBER, "costume #"],
+                [ScratchBlocks.Msg.SENSING_OF_COSTUMENAME, "costume name"],
+                [ScratchBlocks.Msg.SENSING_OF_SIZE, "size"],
+                [ScratchBlocks.Msg.SENSING_OF_VOLUME, "volume"],
             ];
             if (vm.editingTarget) {
                 let lookupBlocks = vm.editingTarget.blocks;
@@ -260,31 +339,44 @@ export default function (vm, useCatBlocks) {
 
                 // The block doesn't exist, but should be in the flyout. Look there.
                 if (!sensingOfBlock) {
-                    sensingOfBlock = vm.runtime.flyoutBlocks.getBlock(blockId) || defaultSensingOfBlock;
+                    sensingOfBlock =
+                        vm.runtime.flyoutBlocks.getBlock(blockId) ||
+                        defaultSensingOfBlock;
                     // If we still don't have a block, just return an empty list . This happens during
                     // scratch blocks construction.
                     if (!sensingOfBlock) {
-                        return [['', '']];
+                        return [["", ""]];
                     }
                     // The block was in the flyout so look up future block info there.
                     lookupBlocks = vm.runtime.flyoutBlocks;
                 }
                 const sort = function (options) {
-                    options.sort(ScratchBlocks.scratchBlocksUtils.compareStrings);
+                    options.sort(
+                        ScratchBlocks.scratchBlocksUtils.compareStrings
+                    );
                 };
                 // Get all the stage variables (no lists) so we can add them to menu when the stage is selected.
-                const stageVariableOptions = vm.runtime.getTargetForStage().getAllVariableNamesInScopeByType('');
+                const stageVariableOptions = vm.runtime
+                    .getTargetForStage()
+                    .getAllVariableNamesInScopeByType("");
                 sort(stageVariableOptions);
-                const stageVariableMenuItems = stageVariableOptions.map(variable => [variable, variable]);
-                if (sensingOfBlock.inputs.OBJECT.shadow !== sensingOfBlock.inputs.OBJECT.block) {
+                const stageVariableMenuItems = stageVariableOptions.map(
+                    (variable) => [variable, variable]
+                );
+                if (
+                    sensingOfBlock.inputs.OBJECT.shadow !==
+                    sensingOfBlock.inputs.OBJECT.block
+                ) {
                     // There's a block dropped on top of the menu. It'd be nice to evaluate it and
                     // return the correct list, but that is tricky. Scratch2 just returns stage options
                     // so just do that here too.
                     return stageOptions.concat(stageVariableMenuItems);
                 }
-                const menuBlock = lookupBlocks.getBlock(sensingOfBlock.inputs.OBJECT.shadow);
+                const menuBlock = lookupBlocks.getBlock(
+                    sensingOfBlock.inputs.OBJECT.shadow
+                );
                 const selectedItem = menuBlock.fields.OBJECT.value;
-                if (selectedItem === '_stage_') {
+                if (selectedItem === "_stage_") {
                     return stageOptions.concat(stageVariableMenuItems);
                 }
                 // Get all the local variables (no lists) and add them to the menu.
@@ -292,13 +384,16 @@ export default function (vm, useCatBlocks) {
                 let spriteVariableOptions = [];
                 // The target should exist, but there are ways for it not to (e.g. #4203).
                 if (target) {
-                    spriteVariableOptions = target.getAllVariableNamesInScopeByType('', true);
+                    spriteVariableOptions =
+                        target.getAllVariableNamesInScopeByType("", true);
                     sort(spriteVariableOptions);
                 }
-                const spriteVariableMenuItems = spriteVariableOptions.map(variable => [variable, variable]);
+                const spriteVariableMenuItems = spriteVariableOptions.map(
+                    (variable) => [variable, variable]
+                );
                 return spriteOptions.concat(spriteVariableMenuItems);
             }
-            return [['', '']];
+            return [["", ""]];
         };
 
         const json = jsonForSensingMenus(menuFn);
@@ -306,32 +401,55 @@ export default function (vm, useCatBlocks) {
     };
 
     ScratchBlocks.Blocks.sensing_distancetomenu.init = function () {
-        const mouse = ScratchBlocks.ScratchMsgs.translate('SENSING_DISTANCETO_POINTER', 'mouse-pointer');
-        const json = jsonForMenuBlock('DISTANCETOMENU', spriteMenu, sensingColors, [
-            [mouse, '_mouse_']
-        ]);
+        const mouse = ScratchBlocks.ScratchMsgs.translate(
+            "SENSING_DISTANCETO_POINTER",
+            "mouse-pointer"
+        );
+        const json = jsonForMenuBlock(
+            "DISTANCETOMENU",
+            spriteMenu,
+            sensingColors,
+            [[mouse, "_mouse_"]]
+        );
         this.jsonInit(json);
     };
 
     ScratchBlocks.Blocks.sensing_touchingobjectmenu.init = function () {
-        const mouse = ScratchBlocks.ScratchMsgs.translate('SENSING_TOUCHINGOBJECT_POINTER', 'mouse-pointer');
-        const edge = ScratchBlocks.ScratchMsgs.translate('SENSING_TOUCHINGOBJECT_EDGE', 'edge');
-        const json = jsonForMenuBlock('TOUCHINGOBJECTMENU', spriteMenu, sensingColors, [
-            [mouse, '_mouse_'],
-            [edge, '_edge_']
-        ]);
+        const mouse = ScratchBlocks.ScratchMsgs.translate(
+            "SENSING_TOUCHINGOBJECT_POINTER",
+            "mouse-pointer"
+        );
+        const edge = ScratchBlocks.ScratchMsgs.translate(
+            "SENSING_TOUCHINGOBJECT_EDGE",
+            "edge"
+        );
+        const json = jsonForMenuBlock(
+            "TOUCHINGOBJECTMENU",
+            spriteMenu,
+            sensingColors,
+            [
+                [mouse, "_mouse_"],
+                [edge, "_edge_"],
+            ]
+        );
         this.jsonInit(json);
     };
 
     ScratchBlocks.Blocks.control_create_clone_of_menu.init = function () {
-        const json = jsonForMenuBlock('CLONE_OPTION', cloneMenu, controlColors, []);
+        const json = jsonForMenuBlock(
+            "CLONE_OPTION",
+            cloneMenu,
+            controlColors,
+            []
+        );
         this.jsonInit(json);
     };
 
-    ScratchBlocks.CheckableContinuousFlyout.prototype.getCheckboxState = function (blockId) {
-        const monitoredBlock = vm.runtime.monitorBlocks._blocks[blockId];
-        return monitoredBlock ? monitoredBlock.isMonitored : false;
-    };
+    ScratchBlocks.CheckableContinuousFlyout.prototype.getCheckboxState =
+        function (blockId) {
+            const monitoredBlock = vm.runtime.monitorBlocks._blocks[blockId];
+            return monitoredBlock ? monitoredBlock.isMonitored : false;
+        };
 
     // ScratchBlocks.FlyoutExtensionCategoryHeader.getExtensionState = function (extensionId) {
     //     if (vm.getPeripheralIsConnected(extensionId)) {
@@ -348,8 +466,8 @@ export default function (vm, useCatBlocks) {
     // creates a collator. Using this is a lot faster in browsers that create a
     // collator for every localeCompare call.
     const collator = new Intl.Collator([], {
-        sensitivity: 'base',
-        numeric: true
+        sensitivity: "base",
+        numeric: true,
     });
     // ScratchBlocks.scratchBlocksUtils.compareStrings = function (str1, str2) {
     //     return collator.compare(str1, str2);

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -177,19 +177,13 @@ export default function (vm, useCatBlocks) {
     ScratchBlocks.Blocks.sound_sounds_menu.init = function () {
         const json = jsonForMenuBlock("SOUND_MENU", soundsMenu, "sounds", []);
         this.jsonInit(json);
-        this.inputList[0].removeField("SOUND_MENU");
-        const dropdown = ScratchBlocks.fieldRegistry.fromJson({
-            type: "field_dropdown",
-            options: soundsMenu(),
-        });
-        dropdown.setValidator((newValue) => {
+        this.getField("SOUND_MENU").setValidator((newValue) => {
             if (newValue === "SOUND_RECORD") {
                 ScratchBlocks.recordSoundCallback();
                 return null;
             }
             return newValue;
         });
-        this.inputList[0].appendField(dropdown, "SOUND_MENU");
     };
 
     ScratchBlocks.Blocks.looks_costume.init = function () {

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -8,7 +8,7 @@ export default function (vm, useCatBlocks) {
     const { ScratchBlocks } = useCatBlocks
         ? require("cat-blocks")
         : require("scratch-blocks");
-    const jsonForMenuBlock = function (name, menuOptionsFn, colors, start) {
+    const jsonForMenuBlock = function (name, menuOptionsFn, category, start) {
         return {
             message0: "%1",
             args0: [
@@ -22,11 +22,8 @@ export default function (vm, useCatBlocks) {
             ],
             inputsInline: true,
             output: "String",
-            colour: colors.secondary,
-            colourSecondary: colors.secondary,
-            colourTertiary: colors.tertiary,
-            colourQuaternary: colors.quaternary,
             outputShape: ScratchBlocks.OUTPUT_SHAPE_ROUND,
+            extensions: [`colours_${category}`],
         };
     };
 
@@ -34,7 +31,7 @@ export default function (vm, useCatBlocks) {
         hatName,
         name,
         menuOptionsFn,
-        colors,
+        category,
         start
     ) {
         return {
@@ -48,11 +45,7 @@ export default function (vm, useCatBlocks) {
                     },
                 },
             ],
-            colour: colors.primary,
-            colourSecondary: colors.secondary,
-            colourTertiary: colors.tertiary,
-            colourQuaternary: colors.quaternary,
-            extensions: ["shape_hat"],
+            extensions: [`colours_${category}`, "shape_hat"],
         };
     };
 
@@ -73,11 +66,8 @@ export default function (vm, useCatBlocks) {
                 },
             ],
             output: true,
-            colour: ScratchBlocks.Colours.sensing.primary,
-            colourSecondary: ScratchBlocks.Colours.sensing.secondary,
-            colourTertiary: ScratchBlocks.Colours.sensing.tertiary,
-            colourQuaternary: ScratchBlocks.Colours.sensing.quaternary,
             outputShape: ScratchBlocks.OUTPUT_SHAPE_ROUND,
+            extensions: ["colours_sensing"],
         };
     };
 
@@ -184,56 +174,31 @@ export default function (vm, useCatBlocks) {
         return [[myself, "_myself_"]].concat(spriteMenu());
     };
 
-    const soundColors = ScratchBlocks.Colours.sounds;
-
-    const looksColors = ScratchBlocks.Colours.looks;
-
-    const motionColors = ScratchBlocks.Colours.motion;
-
-    const sensingColors = ScratchBlocks.Colours.sensing;
-
-    const controlColors = ScratchBlocks.Colours.control;
-
-    const eventColors = ScratchBlocks.Colours.event;
-
     ScratchBlocks.Blocks.sound_sounds_menu.init = function () {
-        const json = jsonForMenuBlock(
-            "SOUND_MENU",
-            soundsMenu,
-            soundColors,
-            []
-        );
+        const json = jsonForMenuBlock("SOUND_MENU", soundsMenu, "sounds", []);
         this.jsonInit(json);
         this.inputList[0].removeField("SOUND_MENU");
-        this.inputList[0].appendField(
-            new ScratchBlocks.FieldDropdown(
-                () => {
-                    return soundsMenu();
-                },
-                (newValue) => {
-                    if (newValue === "SOUND_RECORD") {
-                        ScratchBlocks.recordSoundCallback();
-                        return null;
-                    }
-                    return newValue;
-                }
-            ),
-            "SOUND_MENU"
-        );
+        const dropdown = ScratchBlocks.fieldRegistry.fromJson({
+            type: "field_dropdown",
+            options: soundsMenu(),
+        });
+        dropdown.setValidator((newValue) => {
+            if (newValue === "SOUND_RECORD") {
+                ScratchBlocks.recordSoundCallback();
+                return null;
+            }
+            return newValue;
+        });
+        this.inputList[0].appendField(dropdown, "SOUND_MENU");
     };
 
     ScratchBlocks.Blocks.looks_costume.init = function () {
-        const json = jsonForMenuBlock("COSTUME", costumesMenu, looksColors, []);
+        const json = jsonForMenuBlock("COSTUME", costumesMenu, "looks", []);
         this.jsonInit(json);
     };
 
     ScratchBlocks.Blocks.looks_backdrops.init = function () {
-        const json = jsonForMenuBlock(
-            "BACKDROP",
-            backdropsMenu,
-            looksColors,
-            []
-        );
+        const json = jsonForMenuBlock("BACKDROP", backdropsMenu, "looks", []);
         this.jsonInit(json);
     };
 
@@ -242,7 +207,7 @@ export default function (vm, useCatBlocks) {
             ScratchBlocks.Msg.EVENT_WHENBACKDROPSWITCHESTO,
             "BACKDROP",
             backdropNamesMenu,
-            eventColors,
+            "event",
             []
         );
         this.jsonInit(json);
@@ -253,7 +218,7 @@ export default function (vm, useCatBlocks) {
             "MOTION_POINTTOWARDS_POINTER",
             "mouse-pointer"
         );
-        const json = jsonForMenuBlock("TOWARDS", spriteMenu, motionColors, [
+        const json = jsonForMenuBlock("TOWARDS", spriteMenu, "motion", [
             [mouse, "_mouse_"],
         ]);
         this.jsonInit(json);
@@ -268,7 +233,7 @@ export default function (vm, useCatBlocks) {
             "MOTION_GOTO_POINTER",
             "mouse-pointer"
         );
-        const json = jsonForMenuBlock("TO", spriteMenu, motionColors, [
+        const json = jsonForMenuBlock("TO", spriteMenu, "motion", [
             [random, "_random_"],
             [mouse, "_mouse_"],
         ]);
@@ -284,7 +249,7 @@ export default function (vm, useCatBlocks) {
             "MOTION_GLIDETO_POINTER",
             "mouse-pointer"
         );
-        const json = jsonForMenuBlock("TO", spriteMenu, motionColors, [
+        const json = jsonForMenuBlock("TO", spriteMenu, "motion", [
             [random, "_random_"],
             [mouse, "_mouse_"],
         ]);
@@ -296,7 +261,7 @@ export default function (vm, useCatBlocks) {
             "SENSING_OF_STAGE",
             "Stage"
         );
-        const json = jsonForMenuBlock("OBJECT", spriteMenu, sensingColors, [
+        const json = jsonForMenuBlock("OBJECT", spriteMenu, "sensing", [
             [stage, "_stage_"],
         ]);
         this.jsonInit(json);
@@ -405,12 +370,9 @@ export default function (vm, useCatBlocks) {
             "SENSING_DISTANCETO_POINTER",
             "mouse-pointer"
         );
-        const json = jsonForMenuBlock(
-            "DISTANCETOMENU",
-            spriteMenu,
-            sensingColors,
-            [[mouse, "_mouse_"]]
-        );
+        const json = jsonForMenuBlock("DISTANCETOMENU", spriteMenu, "sensing", [
+            [mouse, "_mouse_"],
+        ]);
         this.jsonInit(json);
     };
 
@@ -426,7 +388,7 @@ export default function (vm, useCatBlocks) {
         const json = jsonForMenuBlock(
             "TOUCHINGOBJECTMENU",
             spriteMenu,
-            sensingColors,
+            "sensing",
             [
                 [mouse, "_mouse_"],
                 [edge, "_edge_"],
@@ -436,12 +398,7 @@ export default function (vm, useCatBlocks) {
     };
 
     ScratchBlocks.Blocks.control_create_clone_of_menu.init = function () {
-        const json = jsonForMenuBlock(
-            "CLONE_OPTION",
-            cloneMenu,
-            controlColors,
-            []
-        );
+        const json = jsonForMenuBlock("CLONE_OPTION", cloneMenu, "control", []);
         this.jsonInit(json);
     };
 


### PR DESCRIPTION
In conjunction with https://github.com/gonfunko/scratch-blocks/pull/152, this PR fixes the appearance of dropdown menus in shadow blocks. When scratch-gui patches block definitions in order to have menu generators which are dependent upon VM state, it had been manually setting the colors to colors exported by scratch-blocks. Instead, we now use the same extension approach that the main block definitions use, which fixes some bugs caused by the inconsistency. This PR also fetches the dropdown field from the registry rather than hardcoding Blockly's in order to bring in a subclass used by scratch-blocks.