### PR TITLE
refactor: improve efficiency of toolbox updates

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -238,16 +238,6 @@ class Blocks extends React.Component {
             this.ScratchBlocks.hideChaff();
         }
 
-        // Only rerender the toolbox when the blocks are visible and the xml is
-        // different from the previously rendered toolbox xml.
-        // Do not check against prevProps.toolboxXML because that may not have been rendered.
-        if (
-            this.props.isVisible &&
-            this.props.toolboxXML !== this._renderedToolboxXML
-        ) {
-            this.requestToolboxUpdate();
-        }
-
         if (this.props.isVisible === prevProps.isVisible) {
             if (this.props.stageSize !== prevProps.stageSize) {
                 // force workspace to redraw for the new stage size
@@ -269,7 +259,6 @@ class Blocks extends React.Component {
                 this.setLocale();
             } else {
                 this.props.vm.refreshWorkspace();
-                this.requestToolboxUpdate();
             }
 
             window.dispatchEvent(new Event("resize"));
@@ -298,7 +287,6 @@ class Blocks extends React.Component {
             .then(() => {
                 this.workspace.getFlyout().setRecyclingEnabled(false);
                 this.props.vm.refreshWorkspace();
-                this.requestToolboxUpdate();
                 this.withToolboxUpdates(() => {
                     this.workspace.getFlyout().setRecyclingEnabled(true);
                 });
@@ -744,7 +732,6 @@ class Blocks extends React.Component {
             )
             .then(() => {
                 this.props.vm.refreshWorkspace();
-                this.updateToolbox(); // To show new variables/custom blocks
             });
     }
     render() {


### PR DESCRIPTION
This PR improves the efficiency of code that performs toolbox updates, generally in response to changing blocks/themes/locales/variables/procedures. There are two major changes:

* In `componentDidMount`, a block of code that updated the toolbox was removed. This block was redundant, because in the if statement on line 261, the same/technically more liberal visibility check is made, and the code then either calls `setLocale` (which updates the toolbox) or directly calls `requestToolboxUpdate`, so the removed code was performing an unnecessary duplicative toolbox update.
* In situations where a call to `this.props.vm.refreshWorkspace()` was directly followed by a call to `this.requestToolboxUpdate()`, the `requestToolboxUpdate()` call has been removed. In the VM, `refreshWorkspace()` [calls `emitWorkspaceUpdate()`](https://github.com/gonfunko/scratch-vm/blob/modern-blockly/src/virtual-machine.js#L1329), which blocks.jsx listens for and runs `onWorkspaceUpdate()` in response to, which in turn calls `this.props.updateToolboxState()`, which in turn calls `updateToolbox()`. As a result, these callsites were all needlessly updating the toolbox twice as well.