### PR TITLE
fix: fix bug that resulted in a variable dialog appearing atop the procedure editor dialog on mobile

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -874,6 +874,7 @@ Blocks.defaultOptions = {
     collapse: false,
     sounds: false,
     trashcan: false,
+    modalInputs: false,
 };
 
 Blocks.defaultProps = {

--- a/src/containers/custom-procedures.jsx
+++ b/src/containers/custom-procedures.jsx
@@ -193,6 +193,7 @@ CustomProcedures.defaultOptions = {
     comments: false,
     collapse: false,
     scrollbars: true,
+    modalInputs: false,
 };
 
 CustomProcedures.defaultProps = {


### PR DESCRIPTION
This PR fixes https://github.com/gonfunko/scratch-blocks/issues/169. Scratch doesn't use modal inputs on mobile like Blockly core does, but because this functionality wasn't being suppressed with the appropriate injection option, when the procedure editor modal was displayed, the default block, which has an editable text field, became focused, and on mobile caused a call to prompt(), resulting in the secondary dialog.