### PR TITLE
fix: prevent exception when switching languages

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -323,14 +323,17 @@ class Blocks extends React.Component {
         this.workspace.getToolbox().forceRerender();
         this._renderedToolboxXML = this.props.toolboxXML;
 
-        const newCategoryScrollPosition =
+        const newCategoryScrollPosition = this.workspace
+            .getFlyout()
+            .getCategoryScrollPosition(selectedCategoryName);
+        if (newCategoryScrollPosition) {
             this.workspace
                 .getFlyout()
-                .getCategoryScrollPosition(selectedCategoryName).y * scale;
-        this.workspace
-            .getFlyout()
-            .getWorkspace()
-            .scrollbar.setY(newCategoryScrollPosition + offsetWithinCategory);
+                .getWorkspace()
+                .scrollbar.setY(
+                    newCategoryScrollPosition.y * scale + offsetWithinCategory
+                );
+        }
 
         const queue = this.toolboxUpdateQueue;
         this.toolboxUpdateQueue = [];


### PR DESCRIPTION
This PR fixes an exception being thrown when switching languages. When the toolbox is refreshed, we attempt to maintain the relative scroll position in the flyout. Unfortunately, this is based on determining the (human-readable) name of the selected toolbox category, which is usually different (and therefore not present) when switching languages. This resulted in an attempt to access `.y` on a null object, with predictable results. Now, we check for null first. This does mean that we don't preserve the flyout scroll position when switching languages, but this is consistent with Scratch's existing behavior.