### PR TITLE
refactor: fix compatibility with checkboxes and category status indicators

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -94,7 +94,7 @@ class Blocks extends React.Component {
         this.ScratchBlocks.ScratchVariables.setPromptHandler(
             this.handlePromptStart
         );
-        this.ScratchBlocks.statusButtonCallback =
+        this.ScratchBlocks.StatusIndicatorLabel.statusButtonCallback =
             this.handleConnectionModalStart;
         this.ScratchBlocks.recordSoundCallback = this.handleOpenSoundRecorder;
 
@@ -110,7 +110,7 @@ class Blocks extends React.Component {
             this.props.useCatBlocks
         );
         this.ScratchBlocks.dialog.setPrompt(this.handlePromptStart);
-        this.ScratchBlocks.statusButtonCallback =
+        this.ScratchBlocks.StatusIndicatorLabel.statusButtonCallback =
             this.handleConnectionModalStart;
         this.ScratchBlocks.recordSoundCallback = this.handleOpenSoundRecorder;
 
@@ -716,7 +716,7 @@ class Blocks extends React.Component {
         this.props.onOpenConnectionModal(extensionId);
     }
     handleStatusButtonUpdate() {
-        this.ScratchBlocks.refreshStatusButtons(this.workspace);
+        this.workspace.getFlyout().refreshStatusButtons();
     }
     handleOpenSoundRecorder() {
         this.props.onOpenSoundRecorder();

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -356,6 +356,8 @@ export default function (vm, useCatBlocks) {
         };
 
         const json = jsonForSensingMenus(menuFn);
+        json["extensions"].push("output_string");
+        console.log(json);
         this.jsonInit(json);
     };
 
@@ -396,19 +398,20 @@ export default function (vm, useCatBlocks) {
         this.jsonInit(json);
     };
 
-    ScratchBlocks.CheckableContinuousFlyout.prototype.getCheckboxState =
-        function (blockId) {
-            const monitoredBlock = vm.runtime.monitorBlocks._blocks[blockId];
-            return monitoredBlock ? monitoredBlock.isMonitored : false;
-        };
+    ScratchBlocks.CheckboxBubble.prototype.isChecked = function (blockId) {
+        const monitoredBlock = vm.runtime.monitorBlocks._blocks[blockId];
+        return monitoredBlock ? monitoredBlock.isMonitored : false;
+    };
 
-    // ScratchBlocks.FlyoutExtensionCategoryHeader.getExtensionState = function (extensionId) {
-    //     if (vm.getPeripheralIsConnected(extensionId)) {
-    //         return ScratchBlocks.StatusButtonState.READY;
-    //     }
-    //     return ScratchBlocks.StatusButtonState.NOT_READY;
-    // };
-    //
+    ScratchBlocks.StatusIndicatorLabel.prototype.getExtensionState = function (
+        extensionId
+    ) {
+        if (vm.getPeripheralIsConnected(extensionId)) {
+            return ScratchBlocks.StatusButtonState.READY;
+        }
+        return ScratchBlocks.StatusButtonState.NOT_READY;
+    };
+
     // ScratchBlocks.FieldNote.playNote_ = function (noteNum, extensionId) {
     //     vm.runtime.emit('PLAY_NOTE', noteNum, extensionId);
     // };

--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -356,8 +356,6 @@ export default function (vm, useCatBlocks) {
         };
 
         const json = jsonForSensingMenus(menuFn);
-        json["extensions"].push("output_string");
-        console.log(json);
         this.jsonInit(json);
     };
 


### PR DESCRIPTION
This PR fixes interoperability between -gui and -blocks once https://github.com/gonfunko/scratch-blocks/pull/212 is merged. In particular, this allows status indicators and reporter/monitor block checkboxes to interact with the VM's state.