### PR TITLE
fix: fix issue that could prevent variables from appearing in the toolbox

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -299,6 +299,7 @@ class Blocks extends React.Component {
             .then(() => {
                 this.workspace.getFlyout().setRecyclingEnabled(false);
                 this.props.vm.refreshWorkspace();
+                this.requestToolboxUpdate();
                 this.withToolboxUpdates(() => {
                     this.workspace.getFlyout().setRecyclingEnabled(true);
                 });


### PR DESCRIPTION
This PR fixes a bug that could cause variables (or other toolbox/flyout changes) to not be reflected when switching between the editor and other modes.