### PR TITLE
fix: use deserialization wrapper

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -522,7 +522,7 @@ class Blocks extends React.Component {
         this.workspace.removeChangeListener(this.toolboxUpdateChangeListener);
         const dom = this.ScratchBlocks.utils.xml.textToDom(data.xml);
         try {
-            this.ScratchBlocks.Xml.clearWorkspaceAndLoadFromXml(
+            this.ScratchBlocks.clearWorkspaceAndLoadFromXml(
                 dom,
                 this.workspace
             );


### PR DESCRIPTION
This PR pairs with https://github.com/gonfunko/scratch-blocks/pull/245 to invoke the newly-introduced deserialization wrapper that properly initializes variables.