### PR TITLE
fix: plumb `FieldNote` through to the VM

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -410,9 +410,9 @@ export default function (vm, useCatBlocks) {
         return ScratchBlocks.StatusButtonState.NOT_READY;
     };
 
-    // ScratchBlocks.FieldNote.playNote_ = function (noteNum, extensionId) {
-    //     vm.runtime.emit('PLAY_NOTE', noteNum, extensionId);
-    // };
+    ScratchBlocks.FieldNote.playNote_ = function (noteNum, extensionId) {
+        vm.runtime.emit("PLAY_NOTE", noteNum, extensionId);
+    };
 
     // Use a collator's compare instead of localeCompare which internally
     // creates a collator. Using this is a lot faster in browsers that create a


### PR DESCRIPTION
This PR fixes part of https://github.com/gonfunko/scratch-blocks/issues/236 by updating `FieldNote` to message the VM when a note is played. This doesn't actually fix the music blocks, I believe because the way the VM/webpack/loading the samples interact is broken, but I think that's been fixed in upstream.